### PR TITLE
Dark Mode adoption

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,11 +5,18 @@ import PackageDescription
 let package = Package(
     name        : "Dark Mode",
     platforms   : [.iOS(.v9)],
-    products    : [.library(name: "Perseus Dark Mode", targets: ["PerseusDarkMode"]),],
+    products    :
+        [
+            .library(name: "Perseus Dark Mode", targets: ["PerseusDarkMode"]),
+            .library(name: "Adopted System UI", targets: ["AdoptedSystemUI"]),
+        ],
     dependencies: [],
     targets     :
         [
             .target(name: "PerseusDarkMode", dependencies: []),
-            .testTarget(name: "DarkModeTests", dependencies: ["PerseusDarkMode"]),
+            .target(name: "AdoptedSystemUI", dependencies: ["PerseusDarkMode"]),
+            
+            .testTarget(name        : "DarkModeTests",
+                        dependencies: ["PerseusDarkMode", "AdoptedSystemUI"]),
         ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -3,9 +3,9 @@
 import PackageDescription
 
 let package = Package(
-    name        : "DarkMode",
+    name        : "Dark Mode",
     platforms   : [.iOS(.v9)],
-    products    : [.library(name: "PerseusDarkMode", targets: ["PerseusDarkMode"]),],
+    products    : [.library(name: "Perseus Dark Mode", targets: ["PerseusDarkMode"]),],
     dependencies: [],
     targets     :
         [

--- a/Sources/AdoptedSystemUI/SemanticColorsAdopted.swift
+++ b/Sources/AdoptedSystemUI/SemanticColorsAdopted.swift
@@ -1,0 +1,26 @@
+import UIKit
+import PerseusDarkMode
+
+// MARK: Semantic colors
+
+protocol UISemanticColorsAdopted
+{
+    // MARK: - Foreground colors
+    ///
+    /// Foreground colors for static text and related elements.
+    ///
+    static var label_Adopted           : UIColor { get }
+    
+}
+
+extension UIColor: UISemanticColorsAdopted
+{
+    // MARK: - Foreground colors
+    
+    static var label_Adopted           : UIColor
+    {
+        AppearanceService.shared.Style == .light ? #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1) : #colorLiteral(red: 0.9999018312, green: 1, blue: 0.9998798966, alpha: 1)
+    }
+    
+}
+

--- a/Sources/AdoptedSystemUI/SemanticColorsAdopted.swift
+++ b/Sources/AdoptedSystemUI/SemanticColorsAdopted.swift
@@ -3,7 +3,7 @@ import PerseusDarkMode
 
 // MARK: Semantic colors
 
-protocol UISemanticColorsAdopted
+public protocol UISemanticColorsAdopted
 {
     // MARK: - Foreground colors
     ///
@@ -17,7 +17,7 @@ extension UIColor: UISemanticColorsAdopted
 {
     // MARK: - Foreground colors
     
-    static var label_Adopted           : UIColor
+    public static var label_Adopted           : UIColor
     {
         AppearanceService.shared.Style == .light ? #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1) : #colorLiteral(red: 0.9999018312, green: 1, blue: 0.9998798966, alpha: 1)
     }

--- a/Sources/AdoptedSystemUI/SystemColorsAdopted.swift
+++ b/Sources/AdoptedSystemUI/SystemColorsAdopted.swift
@@ -3,7 +3,7 @@ import PerseusDarkMode
 
 // MARK: System colors
 
-protocol UISystemColorsAdopted
+public protocol UISystemColorsAdopted
 {
     // MARK: - Default set of system colors
     
@@ -28,17 +28,17 @@ extension UIColor: UISystemColorsAdopted
     ///
     /// System colors.
     ///
-    static var systemOrange_Adopted: UIColor
+    public static var systemOrange_Adopted: UIColor
     {
         AppearanceService.shared.Style == .light ? #colorLiteral(red: 1, green: 0.5843137255, blue: 0, alpha: 1) : #colorLiteral(red: 1, green: 0.6235294118, blue: 0.03921568627, alpha: 1)
     }
     
-    static var systemYellow_Adopted: UIColor
+    public static var systemYellow_Adopted: UIColor
     {
         AppearanceService.shared.Style == .light ? #colorLiteral(red: 1, green: 0.8, blue: 0, alpha: 1) : #colorLiteral(red: 1, green: 0.8392156863, blue: 0.03921568627, alpha: 1)
     }
     
-    static var systemBrown_Adopted : UIColor
+    public static var systemBrown_Adopted : UIColor
     {
         AppearanceService.shared.Style == .light ? #colorLiteral(red: 0.6352941176, green: 0.5176470588, blue: 0.368627451, alpha: 1) : #colorLiteral(red: 0.6745098039, green: 0.5568627451, blue: 0.4078431373, alpha: 1)
     }
@@ -46,12 +46,12 @@ extension UIColor: UISystemColorsAdopted
     ///
     /// System gray group.
     ///
-    static var systemGray_Adopted  : UIColor
+    public static var systemGray_Adopted  : UIColor
     {
         AppearanceService.shared.Style == .light ? #colorLiteral(red: 0.5568627451, green: 0.5568627451, blue: 0.5764705882, alpha: 1) : #colorLiteral(red: 0.5568627451, green: 0.5568627451, blue: 0.5764705882, alpha: 1)
     }
     
-    static var systemGray2_Adopted : UIColor
+    public static var systemGray2_Adopted : UIColor
     {
         AppearanceService.shared.Style == .light ? #colorLiteral(red: 0.6823529412, green: 0.6823529412, blue: 0.6980392157, alpha: 1) : #colorLiteral(red: 0.3882352941, green: 0.3882352941, blue: 0.4, alpha: 1)
     }

--- a/Sources/AdoptedSystemUI/SystemColorsAdopted.swift
+++ b/Sources/AdoptedSystemUI/SystemColorsAdopted.swift
@@ -1,0 +1,58 @@
+import UIKit
+import PerseusDarkMode
+
+// MARK: System colors
+
+protocol UISystemColorsAdopted
+{
+    // MARK: - Default set of system colors
+    
+    ///
+    /// System colors.
+    ///
+    static var systemOrange_Adopted: UIColor { get }
+    static var systemYellow_Adopted: UIColor { get }
+    static var systemBrown_Adopted : UIColor { get }
+    
+    ///
+    /// System gray group.
+    ///
+    static var systemGray_Adopted  : UIColor { get }
+    static var systemGray2_Adopted : UIColor { get }
+    
+    // MARK: - Accessible set of system colors
+}
+
+extension UIColor: UISystemColorsAdopted
+{
+    ///
+    /// System colors.
+    ///
+    static var systemOrange_Adopted: UIColor
+    {
+        AppearanceService.shared.Style == .light ? #colorLiteral(red: 1, green: 0.5843137255, blue: 0, alpha: 1) : #colorLiteral(red: 1, green: 0.6235294118, blue: 0.03921568627, alpha: 1)
+    }
+    
+    static var systemYellow_Adopted: UIColor
+    {
+        AppearanceService.shared.Style == .light ? #colorLiteral(red: 1, green: 0.8, blue: 0, alpha: 1) : #colorLiteral(red: 1, green: 0.8392156863, blue: 0.03921568627, alpha: 1)
+    }
+    
+    static var systemBrown_Adopted : UIColor
+    {
+        AppearanceService.shared.Style == .light ? #colorLiteral(red: 0.6352941176, green: 0.5176470588, blue: 0.368627451, alpha: 1) : #colorLiteral(red: 0.6745098039, green: 0.5568627451, blue: 0.4078431373, alpha: 1)
+    }
+    
+    ///
+    /// System gray group.
+    ///
+    static var systemGray_Adopted  : UIColor
+    {
+        AppearanceService.shared.Style == .light ? #colorLiteral(red: 0.5568627451, green: 0.5568627451, blue: 0.5764705882, alpha: 1) : #colorLiteral(red: 0.5568627451, green: 0.5568627451, blue: 0.5764705882, alpha: 1)
+    }
+    
+    static var systemGray2_Adopted : UIColor
+    {
+        AppearanceService.shared.Style == .light ? #colorLiteral(red: 0.6823529412, green: 0.6823529412, blue: 0.6980392157, alpha: 1) : #colorLiteral(red: 0.3882352941, green: 0.3882352941, blue: 0.4, alpha: 1)
+    }
+}

--- a/Sources/PerseusDarkMode/AppearanceService/AppearanceService.swift
+++ b/Sources/PerseusDarkMode/AppearanceService/AppearanceService.swift
@@ -1,0 +1,82 @@
+import UIKit
+
+public protocol AppearanceAdaptableElement
+{
+    func adoptAppearance()
+}
+
+public class AppearanceService
+{
+    // MARK: - Singleton
+    
+    public static var shared: DarkMode =
+        {
+            let instance = DarkMode()
+            
+            // Additional setup after initialisation.
+            
+            instance.userDefaults = UserDefaults.standard
+            
+            return instance
+        }()
+    
+    private init() { }
+    
+    // MARK: - Subscribers
+    
+    private static var adoptableElements = Set<UIResponder>()
+    
+    // MARK: - Public API: register subscriber
+    
+    public static func register(_ screenElement: AppearanceAdaptableElement)
+    {
+        guard let element = screenElement as? UIResponder else { return }
+        
+        adoptableElements.insert(element)
+    }
+    
+    // MARK: - Public API: unregister subscriber
+    
+    public static func unregister(_ screenElement: AppearanceAdaptableElement)
+    {
+        guard let element = screenElement as? UIResponder else { return }
+        
+        adoptableElements.remove(element)
+    }
+    
+    // MARK: - Public API: call each subscriber to adopt appearance
+    
+    public static func adoptToDarkMode()
+    {
+        shared.isEnabled = true
+        
+        guard adoptableElements.isEmpty != true else { return }
+        
+        // Adopt system controls in according with Dark Mode
+        
+        if #available(iOS 13.0, *),
+           let keyWindow = UIApplication.shared.keyWindow
+        {
+            switch AppearanceService.shared.DarkModeUserChoice
+            {
+            case .auto:
+                keyWindow.overrideUserInterfaceStyle = .unspecified
+            case .on:
+                keyWindow.overrideUserInterfaceStyle = .dark
+            case .off:
+                keyWindow.overrideUserInterfaceStyle = .light
+            }
+        }
+        
+        // Adopt sibscriber's UI elements in according with Dark Mode
+        
+        adoptableElements.forEach(
+            { item in
+                
+                if let element = item as? AppearanceAdaptableElement
+                {
+                    element.adoptAppearance()
+                }
+            })
+    }
+}

--- a/Sources/PerseusDarkMode/AppearanceService/AppearanceStyle.swift
+++ b/Sources/PerseusDarkMode/AppearanceService/AppearanceStyle.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public enum AppearanceStyle: Int, CustomStringConvertible
+{
+    case light = 0
+    case dark = 1
+    
+    public var description: String
+    {
+        switch self
+        {
+        case .light:
+            return "Light"
+        case .dark:
+            return "Dark"
+        }
+    }
+}
+
+public enum SystemStyle: Int
+{
+    case unspecified = 0
+    case light = 1
+    case dark = 2
+}

--- a/Sources/PerseusDarkMode/DarkMode/Constants.swift
+++ b/Sources/PerseusDarkMode/DarkMode/Constants.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public let DARK_MODE_USER_CHOICE_OPTION_KEY = "DarkModeUserChoiceOptionKey"
+public let DARK_MODE_USER_CHOICE_DEFAULT = DarkModeOption.auto
+public let DARK_MODE_STYLE_DEFAULT = AppearanceStyle.dark

--- a/Sources/PerseusDarkMode/DarkMode/DarkMode.swift
+++ b/Sources/PerseusDarkMode/DarkMode/DarkMode.swift
@@ -4,9 +4,40 @@ public class DarkMode
 {
     // MARK: - Dark Mode Style
     
+    public var Style             : AppearanceStyle
+    {
+        DarkModeDecision.calculateActualStyle(DarkModeUserChoice)
+    }
+    
     public var isEnabled         : Bool = false { willSet { if newValue == false { return } } }
     
     // MARK: - Dark Mode Style saved in UserDafaults
     
     public var userDefaults      : UserDefaults?
+    
+    public var DarkModeUserChoice: DarkModeOption
+    {
+        get
+        {
+            guard let ud = userDefaults else { return DARK_MODE_USER_CHOICE_DEFAULT }
+            
+            // load enum int value
+            
+            let rawValue = ud.valueExists(forKey: DARK_MODE_USER_CHOICE_OPTION_KEY) ?
+                ud.integer(forKey: DARK_MODE_USER_CHOICE_OPTION_KEY) :
+                DARK_MODE_USER_CHOICE_DEFAULT.rawValue
+            
+            // try to cast int value to enum
+            
+            if let result = DarkModeOption.init(rawValue: rawValue) { return result }
+            
+            return DARK_MODE_USER_CHOICE_DEFAULT
+        }
+        set
+        {
+            guard let ud = userDefaults else { return }
+            
+            ud.setValue(newValue.rawValue, forKey: DARK_MODE_USER_CHOICE_OPTION_KEY)
+        }
+    }
 }

--- a/Sources/PerseusDarkMode/DarkMode/DarkModeDecision.swift
+++ b/Sources/PerseusDarkMode/DarkMode/DarkModeDecision.swift
@@ -1,0 +1,76 @@
+import UIKit
+
+// MARK: - Calculations
+
+public class DarkModeDecision
+{
+    // MARK: - Private init
+    
+    private init() { }
+    
+    // MARK: - Calculating Dark Mode decision
+    
+    /// Decision table for Actual Style
+    ///
+    /// — — — — — — — — — — — — — — DarkModeOption — — — — —
+    /// — — — — — — — — — — — — auto — — — on — — — — off  — —
+    /// — — — — — — — — — — — — — — — — — — — — — — — — —
+    /// System style  .unspecified            default            dark              light
+    /// System style  .light                         light               dark              light
+    /// System style  .dark                         dark              dark              light
+    /// — — — — — — — — — — — — — — — — — — — — — — — — —
+    ///
+    public class func calculateActualStyle(_ userChoice: DarkModeOption) -> AppearanceStyle
+    {
+        // Inputs
+        
+        let userChoice = userChoice
+        let systemStyle = calculateSystemStyle()
+        
+        // Calculate outputs
+        
+        if (systemStyle == .unspecified) && (userChoice == .auto)
+        {
+            return DARK_MODE_STYLE_DEFAULT
+        }
+        if (systemStyle == .unspecified) && (userChoice == .on) { return .dark}
+        if (systemStyle == .unspecified) && (userChoice == .off) { return .light}
+        
+        if (systemStyle == .light) && (userChoice == .auto) { return .light }
+        if (systemStyle == .light) && (userChoice == .on) { return .dark}
+        if (systemStyle == .light) && (userChoice == .off) { return .light}
+        
+        if (systemStyle == .dark) && (userChoice == .auto) { return .dark }
+        if (systemStyle == .dark) && (userChoice == .on) { return .dark}
+        if (systemStyle == .dark) && (userChoice == .off) { return .light}
+        
+        // Output default value if somethings goes out of the decision table
+        
+        return DARK_MODE_STYLE_DEFAULT
+    }
+    
+    public class func calculateSystemStyle() -> SystemStyle
+    {
+        if #available(iOS 13.0, *)
+        {
+            guard let keyWindow = UIApplication.shared.keyWindow else { return .unspecified }
+            
+            switch keyWindow.traitCollection.userInterfaceStyle
+            {
+            case .unspecified:
+                return .unspecified
+            case .light:
+                return .light
+            case .dark:
+                return .dark
+                
+            @unknown default:
+                return .unspecified
+            }
+        }
+        else
+        {
+            return .unspecified
+        }
+    }
+}

--- a/Sources/PerseusDarkMode/DarkMode/DarkModeOption.swift
+++ b/Sources/PerseusDarkMode/DarkMode/DarkModeOption.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public enum DarkModeOption: Int, CustomStringConvertible
+{
+    case auto = 0
+    case on = 1
+    case off = 2
+    
+    public var description: String
+    {
+        switch self
+        {
+        case .auto:
+            return "Auto"
+        case .on:
+            return "On"
+        case .off:
+            return "Off"
+        }
+    }
+}

--- a/Sources/PerseusDarkMode/SetupByDefault.swift
+++ b/Sources/PerseusDarkMode/SetupByDefault.swift
@@ -1,17 +1,29 @@
 import UIKit
 
-public class AppearanceService
+public extension UIViewController { var DarkMode: DarkMode { AppearanceService.shared } }
+public extension UIView { var DarkMode: DarkMode { AppearanceService.shared } }
+
+public class UIWindowAdoptable: UIWindow
 {
-    public static var shared: DarkMode =
-        {
-            let instance = DarkMode()
-            
-            // Additional setup after initialisation.
-            
-            instance.userDefaults = UserDefaults.standard
-            
-            return instance
-        }()
-    
-    private init() { }
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?)
+    {
+        guard
+            #available(iOS 13.0, *),
+            let previousSystemStyle = previousTraitCollection?.userInterfaceStyle,
+            previousSystemStyle.rawValue != DarkModeDecision.calculateSystemStyle().rawValue
+        else { return }
+        
+        AppearanceService.adoptToDarkMode()
+    }
 }
+
+// Local helpers
+
+extension UserDefaults
+{
+    func valueExists(forKey key: String) -> Bool
+    {
+        return object(forKey: key) != nil
+    }
+}
+

--- a/Tests/DarkModeTests/DarkModeTests.swift
+++ b/Tests/DarkModeTests/DarkModeTests.swift
@@ -1,10 +1,12 @@
 import XCTest
 @testable import PerseusDarkMode
+@testable import AdoptedSystemUI
 
 final class DarkModeTests: XCTestCase
 {
     func testInit()
     {
         XCTAssertFalse(AppearanceService.shared.isEnabled)
+        
     }
 }


### PR DESCRIPTION
Appearance service was designed and included to the package to support Dark Mode starting from iOS 9.0.

Appearance service includes two libraries. The first one has responsibility for giving the single sensitive point for Dark Mode. Another one contains system UI (appearance) elements such as colors adopted from higher iOS releases.

ADDED: Business logic implementing Dark Mode adoption idea.

ADDED: Draft for adopted system colors.

ADDED: Draft for adopted semantic colors.