### PR TITLE
Unit test for semantic colors

### DIFF
--- a/Sources/AdaptedSystemUI/ColorHelper.swift
+++ b/Sources/AdaptedSystemUI/ColorHelper.swift
@@ -1,0 +1,30 @@
+//
+// ColorHelper.swift
+// AdaptedSystemUI
+//
+// Copyright © 2022 Mikhail Zhigulin. All rights reserved.
+
+import UIKit
+
+public func rgba255(_ red  : CGFloat,
+                    _ green: CGFloat,
+                    _ blue : CGFloat,
+                    _ alpha: CGFloat = 1.0) -> UIColor
+{
+    return UIColor(red: red/255, green: green/255, blue: blue/255, alpha: alpha)
+}
+
+public extension UIColor
+{
+    var RGBA255: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat)
+    {
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        
+        getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        
+        return (red*255, green*255, blue*255, alpha)
+    }
+}

--- a/Sources/AdaptedSystemUI/SemanticColorsAdapted.swift
+++ b/Sources/AdaptedSystemUI/SemanticColorsAdapted.swift
@@ -69,50 +69,58 @@ extension UIColor: UISemanticColorsAdapted
     ///
     public static var label_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .label }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(255, 255, 255) : rgba255(0, 0, 0)
             
-            UIColor(red: 52/255, green: 199/255, blue: 89/255, alpha: 1.0) :
-            UIColor(red: 48/255, green: 209/255, blue: 88/255, alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .label
     }
     
     public static var secondaryLabel_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .secondaryLabel }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(235, 235, 245, 0.6) : rgba255(60, 60, 67, 0.6)
             
-            UIColor(red: 235/255, green: 235/255, blue: 245/255, alpha: 0.6) :
-            UIColor(red: 60/255,  green: 60/255,  blue: 67/255,  alpha: 0.6)
+            return color
+        }
         
-        return color
+        return .secondaryLabel
     }
     
     public static var tertiaryLabel_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .tertiaryLabel }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(235, 235, 245, 0.3) : rgba255(60, 60, 67, 0.3)
             
-            UIColor(red: 235/255, green: 235/255, blue: 245/255, alpha: 0.3) :
-            UIColor(red: 60/255,  green: 60/255,  blue: 67/255,  alpha: 0.3)
+            return color
+        }
         
-        return color
+        return .tertiaryLabel
     }
     
     public static var quaternaryLabel_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .quaternaryLabel }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(235, 235, 245, 0.18) : rgba255(60, 60, 67, 0.18)
             
-            UIColor(red: 235/255, green: 235/255, blue: 245/255, alpha: 0.18) :
-            UIColor(red: 60/255,  green: 60/255,  blue: 67/255,  alpha: 0.18)
+            return color
+        }
         
-        return color
+        return .quaternaryLabel
     }
     
     ///
@@ -120,14 +128,16 @@ extension UIColor: UISemanticColorsAdapted
     ///
     public static var placeholderText_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .placeholderText }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(235, 235, 245, 0.3) : rgba255(60, 60, 67, 0.3)
             
-            UIColor(red: 235/255, green: 235/255, blue: 245/255, alpha: 0.3) :
-            UIColor(red: 60/255,  green: 60/255,  blue: 67/255,  alpha: 0.3)
+            return color
+        }
         
-        return color
+        return .placeholderText
     }
     
     ///
@@ -135,26 +145,30 @@ extension UIColor: UISemanticColorsAdapted
     ///
     public static var separator_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .separator }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(84, 84, 88, 0.6) : rgba255(60, 60, 67, 0.29)
             
-            UIColor(red: 84/255, green: 84/255, blue: 88/255, alpha: 0.6) :
-            UIColor(red: 60/255, green: 60/255, blue: 67/255, alpha: 0.29)
+            return color
+        }
         
-        return color
+        return .separator
     }
     
     public static var opaqueSeparator_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .opaqueSeparator }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(56, 56, 58) : rgba255(198, 198, 200)
             
-            UIColor(red: 56/255,  green: 56/255,  blue: 58/255,  alpha: 1.0) :
-            UIColor(red: 198/255, green: 198/255, blue: 200/255, alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .opaqueSeparator
     }
     
     ///
@@ -162,14 +176,16 @@ extension UIColor: UISemanticColorsAdapted
     ///
     public static var link_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .link }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(9, 132, 255) : rgba255(0, 122, 255)
             
-            UIColor(red: 9/255, green: 132/255, blue: 1.0, alpha: 1.0) :
-            UIColor(red: 0.0,   green: 122/255, blue: 1.0, alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .link
     }
     
     ///
@@ -177,50 +193,58 @@ extension UIColor: UISemanticColorsAdapted
     ///
     public static var systemFill_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .systemFill }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(120, 120, 128, 0.36) : rgba255(120, 120, 128, 0.2)
             
-            UIColor(red: 120/255, green: 120/255, blue: 128/255, alpha: 0.36) :
-            UIColor(red: 120/255, green: 120/255, blue: 128/255, alpha: 0.2)
+            return color
+        }
         
-        return color
+        return .systemFill
     }
     
     public static var secondarySystemFill_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .secondarySystemFill }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(120, 120, 128, 0.32) : rgba255(120, 120, 128, 0.16)
             
-            UIColor(red: 120/255, green: 120/255, blue: 128/255, alpha: 0.32) :
-            UIColor(red: 120/255, green: 120/255, blue: 128/255, alpha: 0.16)
+            return color
+        }
         
-        return color
+        return .secondarySystemFill
     }
     
     public static var tertiarySystemFilll_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .tertiarySystemFill }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(118, 118, 128, 0.24) : rgba255(118, 118, 128, 0.12)
             
-            UIColor(red: 118/255, green: 118/255, blue: 128/255, alpha: 0.24) :
-            UIColor(red: 118/255, green: 118/255, blue: 128/255, alpha: 0.12)
+            return color
+        }
         
-        return color
+        return .tertiarySystemFill
     }
     
     public static var quaternarySystemFill_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .quaternarySystemFill }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(118, 118, 128, 0.18) : rgba255(116, 116, 128, 0.08)
             
-            UIColor(red: 118/255, green: 118/255, blue: 128/255, alpha: 0.18) :
-            UIColor(red: 116/255, green: 116/255, blue: 128/255, alpha: 0.08)
+            return color
+        }
         
-        return color
+        return .quaternarySystemFill
     }
     
     // MARK: - Background
@@ -230,38 +254,44 @@ extension UIColor: UISemanticColorsAdapted
     ///
     public static var systemBackground_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .systemBackground }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(0, 0, 0) : rgba255(255, 255, 255)
             
-            UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0) :
-            UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .systemBackground
     }
     
     public static var secondarySystemBackground_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .secondarySystemBackground }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(28, 28, 30) : rgba255(242, 242, 247)
             
-            UIColor(red: 28/255,  green: 28/255,  blue: 30/255,  alpha: 1.0) :
-            UIColor(red: 242/255, green: 242/255, blue: 247/255, alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .secondarySystemBackground
     }
     
     public static var tertiarySystemBackground_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .tertiarySystemBackground }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(44, 44, 46) : rgba255(255, 255, 255)
             
-            UIColor(red: 44/255, green: 44/255, blue: 46/255, alpha: 1.0) :
-            UIColor(red: 1.0,    green: 1.0,    blue: 1.0,    alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .tertiarySystemBackground
     }
     
     ///
@@ -269,37 +299,43 @@ extension UIColor: UISemanticColorsAdapted
     ///
     public static var systemGroupedBackground_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .systemGroupedBackground }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(0, 0, 0) : rgba255(242, 242, 247)
             
-            UIColor(red: 0.0,     green: 0.0,     blue: 0.0,     alpha: 1.0) :
-            UIColor(red: 242/255, green: 242/255, blue: 247/255, alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .systemGroupedBackground
     }
     
     public static var secondarySystemGroupedBackground_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .secondarySystemGroupedBackground }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(28, 28, 30) : rgba255(255, 255, 255)
             
-            UIColor(red: 28/255, green: 28/255, blue: 30/255, alpha: 1.0) :
-            UIColor(red: 1.0,    green: 1.0,    blue: 1.0,    alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .secondarySystemGroupedBackground
     }
     
     public static var tertiarySystemGroupedBackground_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .tertiarySystemGroupedBackground }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(44, 44, 46) : rgba255(242, 242, 247)
             
-            UIColor(red: 44/255,  green: 44/255,  blue: 46/255,  alpha: 1.0) :
-            UIColor(red: 242/255, green: 242/255, blue: 247/255, alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .tertiarySystemGroupedBackground
     }
 }

--- a/Sources/AdaptedSystemUI/SystemColorsAdapted.swift
+++ b/Sources/AdaptedSystemUI/SystemColorsAdapted.swift
@@ -47,14 +47,16 @@ extension UIColor: UISystemColorsAdapted
     ///
     public static var systemRed_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .systemRed }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(255, 59, 48) : rgba255(255, 69, 58)
             
-            UIColor(red: 1.0, green: 59/255, blue: 48/255, alpha: 1.0) :
-            UIColor(red: 1.0, green: 69/255, blue: 58/255, alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .systemRed
     }
     
     ///
@@ -62,14 +64,16 @@ extension UIColor: UISystemColorsAdapted
     ///
     public static var systemOrange_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .systemOrange }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(255, 149, 0) : rgba255(255, 159, 10)
             
-            UIColor(red: 1.0, green: 149/255, blue: 0.0,    alpha: 1.0) :
-            UIColor(red: 1.0, green: 159/255, blue: 10/255, alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .systemOrange
     }
     
     ///
@@ -77,14 +81,16 @@ extension UIColor: UISystemColorsAdapted
     ///
     public static var systemYellow_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .systemYellow }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(255, 204, 0) : rgba255(255, 214, 10)
             
-            UIColor(red: 1.0, green: 204/255, blue: 0.0,    alpha: 1.0) :
-            UIColor(red: 1.0, green: 214/255, blue: 10/255, alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .systemYellow
     }
     
     ///
@@ -92,14 +98,16 @@ extension UIColor: UISystemColorsAdapted
     ///
     public static var systemGreen_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .systemGreen }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(52, 199, 89) : rgba255(48, 209, 88)
             
-            UIColor(red: 52/255, green: 199/255, blue: 89/255, alpha: 1.0) :
-            UIColor(red: 48/255, green: 209/255, blue: 88/255, alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .systemGreen
     }
     
     ///
@@ -109,8 +117,7 @@ extension UIColor: UISystemColorsAdapted
     {
         let color = AppearanceService.shared.Style == .light ?
             
-            UIColor(red: 0.0,     green: 199/255, blue: 190/255, alpha: 1.0) :
-            UIColor(red: 102/255, green: 212/255, blue: 207/255, alpha: 1.0)
+            rgba255(0, 199, 190) : rgba255(102, 212, 207)
         
         return color
     }
@@ -120,14 +127,16 @@ extension UIColor: UISystemColorsAdapted
     ///
     public static var systemTeal_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .systemTeal }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(48, 176, 199) : rgba255(64, 200, 224)
             
-            UIColor(red: 48/255, green: 176/255, blue: 199/255, alpha: 1.0) :
-            UIColor(red: 64/255, green: 200/255, blue: 224/255, alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .systemTeal
     }
     
     ///
@@ -137,8 +146,7 @@ extension UIColor: UISystemColorsAdapted
     {
         let color = AppearanceService.shared.Style == .light ?
             
-            UIColor(red: 50/255,  green: 173/255, blue: 230/255, alpha: 1.0) :
-            UIColor(red: 100/255, green: 210/255, blue: 1.0,     alpha: 1.0)
+            rgba255(50, 173, 230) : rgba255(100, 210, 255)
         
         return color
     }
@@ -148,14 +156,16 @@ extension UIColor: UISystemColorsAdapted
     ///
     public static var systemBlue_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .systemBlue }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(0, 122, 255) : rgba255(10, 132, 255)
             
-            UIColor(red: 0.0,    green: 122/255, blue: 1.0, alpha: 1.0) :
-            UIColor(red: 10/255, green: 132/255, blue: 1.0, alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .systemBlue
     }
     
     ///
@@ -163,14 +173,16 @@ extension UIColor: UISystemColorsAdapted
     ///
     public static var systemIndigo_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .systemIndigo }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(88, 86, 214) : rgba255(94, 92, 230)
             
-            UIColor(red: 88/255, green: 86/255, blue: 214/255, alpha: 1.0) :
-            UIColor(red: 94/255, green: 92/255, blue: 230/255, alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .systemIndigo
     }
     
     ///
@@ -178,14 +190,16 @@ extension UIColor: UISystemColorsAdapted
     ///
     public static var systemPurple_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .systemPurple }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(175, 82, 222) : rgba255(191, 90, 242)
             
-            UIColor(red: 175/255, green: 82/255, blue: 222/255, alpha: 1.0) :
-            UIColor(red: 191/255, green: 90/255, blue: 242/255, alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .systemPurple
     }
     
     ///
@@ -193,14 +207,16 @@ extension UIColor: UISystemColorsAdapted
     ///
     public static var systemPink_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return .systemPink }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(255, 45, 85) : rgba255(255, 55, 95)
             
-            UIColor(red: 1.0, green: 45/255, blue: 85/255, alpha: 1.0) :
-            UIColor(red: 1.0, green: 55/255, blue: 95/255, alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .systemPink
     }
     
     ///
@@ -210,8 +226,7 @@ extension UIColor: UISystemColorsAdapted
     {
         let color = AppearanceService.shared.Style == .light ?
             
-            UIColor(red: 162/255, green: 132/255, blue: 94/255,  alpha: 1.0) :
-            UIColor(red: 172/255, green: 142/255, blue: 104/255, alpha: 1.0)
+            rgba255(162, 132, 94) : rgba255(172, 142, 104)
         
         return color
     }
@@ -221,14 +236,16 @@ extension UIColor: UISystemColorsAdapted
     ///
     public static var systemGray_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return systemGray }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(142, 142, 147) : rgba255(142, 142, 147)
             
-            UIColor(red: 142/255, green: 142/255, blue: 147/255, alpha: 1.0) :
-            UIColor(red: 142/255, green: 142/255, blue: 147/255, alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .systemGray
     }
     
     ///
@@ -236,14 +253,16 @@ extension UIColor: UISystemColorsAdapted
     ///
     public static var systemGray2_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return systemGray2 }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(174, 174, 178) : rgba255(99, 99, 102)
             
-            UIColor(red: 174/255, green: 174/255, blue: 178/255, alpha: 1.0) :
-            UIColor(red: 99/255,  green: 99/255,  blue: 102/255, alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .systemGray2
     }
     
     ///
@@ -251,14 +270,16 @@ extension UIColor: UISystemColorsAdapted
     ///
     public static var systemGray3_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return systemGray3 }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(199, 199, 204) : rgba255(72, 72, 74)
             
-            UIColor(red: 199/255, green: 199/255, blue: 204/255, alpha: 1.0) :
-            UIColor(red: 72/255,  green: 72/255,  blue: 74/255,  alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .systemGray3
     }
     
     ///
@@ -266,14 +287,16 @@ extension UIColor: UISystemColorsAdapted
     ///
     public static var systemGray4_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return systemGray4 }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(209, 209, 214) : rgba255(58, 58, 60)
             
-            UIColor(red: 209/255, green: 209/255, blue: 214/255, alpha: 1.0) :
-            UIColor(red: 58/255,  green: 58/255,  blue: 60/255,  alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .systemGray4
     }
     
     ///
@@ -281,14 +304,16 @@ extension UIColor: UISystemColorsAdapted
     ///
     public static var systemGray5_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return systemGray5 }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(229, 229, 234) : rgba255(44, 44, 46)
             
-            UIColor(red: 229/255, green: 229/255, blue: 234/255, alpha: 1.0) :
-            UIColor(red: 44/255,  green: 44/255,  blue: 46/255,  alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .systemGray5
     }
     
     ///
@@ -296,13 +321,15 @@ extension UIColor: UISystemColorsAdapted
     ///
     public static var systemGray6_Adapted: UIColor
     {
-        if #available(iOS 13.0, *) { return systemGray6 }
-        
-        let color = AppearanceService.shared.Style == .light ?
+        guard #available(iOS 13.0, *) else
+        {
+            let color = AppearanceService.shared.Style == .light ?
+                
+                rgba255(199, 199, 204) : rgba255(28, 28, 30)
             
-            UIColor(red: 199/255, green: 199/255, blue: 204/255, alpha: 1.0) :
-            UIColor(red: 28/255,  green: 28/255,  blue: 30/255,  alpha: 1.0)
+            return color
+        }
         
-        return color
+        return .systemGray6
     }
 }

--- a/Sources/PerseusDarkMode/AppearanceService/AppearanceService.swift
+++ b/Sources/PerseusDarkMode/AppearanceService/AppearanceService.swift
@@ -8,7 +8,7 @@ import UIKit
 
 public protocol AppearanceAdaptableElement
 {
-    func adoptAppearance()
+    func adaptAppearance()
 }
 
 public class AppearanceService
@@ -30,7 +30,7 @@ public class AppearanceService
     
     // MARK: - Subscribers
     
-    private static var adoptableElements = Set<UIResponder>()
+    private static var adaptableElements = Set<UIResponder>()
     
     // MARK: - Public API: register subscriber
     
@@ -38,7 +38,7 @@ public class AppearanceService
     {
         guard let element = screenElement as? UIResponder else { return }
         
-        adoptableElements.insert(element)
+        adaptableElements.insert(element)
     }
     
     // MARK: - Public API: unregister subscriber
@@ -47,16 +47,16 @@ public class AppearanceService
     {
         guard let element = screenElement as? UIResponder else { return }
         
-        adoptableElements.remove(element)
+        adaptableElements.remove(element)
     }
     
-    // MARK: - Public API: call each subscriber to adopt appearance
+    // MARK: - Public API: call each subscriber to adapt appearance
     
-    public static func adoptToDarkMode()
+    public static func adaptToDarkMode()
     {
         shared.isEnabled = true
         
-        guard adoptableElements.isEmpty != true else { return }
+        guard adaptableElements.isEmpty != true else { return }
         
         // Adopt system controls in according with Dark Mode
         
@@ -76,12 +76,12 @@ public class AppearanceService
         
         // Adopt sibscriber's UI elements in according with Dark Mode
         
-        adoptableElements.forEach(
+        adaptableElements.forEach(
             { item in
                 
                 if let element = item as? AppearanceAdaptableElement
                 {
-                    element.adoptAppearance()
+                    element.adaptAppearance()
                 }
             })
     }

--- a/Sources/PerseusDarkMode/SetupByDefault.swift
+++ b/Sources/PerseusDarkMode/SetupByDefault.swift
@@ -9,7 +9,7 @@ import UIKit
 public extension UIViewController { var DarkMode: DarkMode { AppearanceService.shared } }
 public extension UIView { var DarkMode: DarkMode { AppearanceService.shared } }
 
-public class UIWindowAdoptable: UIWindow
+public class UIWindowAdaptable: UIWindow
 {
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?)
     {
@@ -19,7 +19,7 @@ public class UIWindowAdoptable: UIWindow
             previousSystemStyle.rawValue != DarkModeDecision.calculateSystemStyle().rawValue
         else { return }
         
-        AppearanceService.adoptToDarkMode()
+        AppearanceService.adaptToDarkMode()
     }
 }
 
@@ -32,4 +32,3 @@ extension UserDefaults
         return object(forKey: key) != nil
     }
 }
-

--- a/Tests/DarkModeTests/DarkModeTests.swift
+++ b/Tests/DarkModeTests/DarkModeTests.swift
@@ -10,9 +10,9 @@ import XCTest
 
 final class DarkModeTests: XCTestCase
 {
-    func testInit()
+    func test_Init()
     {
         XCTAssertFalse(AppearanceService.shared.isEnabled)
-        
     }
 }
+

--- a/Tests/DarkModeTests/Helpers/ColorRequirement.swift
+++ b/Tests/DarkModeTests/Helpers/ColorRequirement.swift
@@ -1,0 +1,79 @@
+//
+// ColorRequirement.swift
+// DarkModeTests
+//
+// Copyright © 2022 Mikhail Zhigulin. All rights reserved.
+
+import UIKit
+@testable import AdaptedSystemUI
+
+enum ColorRequirement
+{
+    case label
+    case secondaryLabel
+    case tertiaryLabel
+    case quaternaryLabel
+    case placeholderText
+    case separator
+    case opaqueSeparator
+    case link
+    
+    case systemFill
+    case secondarySystemFill
+    case tertiarySystemFilll
+    case quaternarySystemFill
+    
+    case systemBackground
+    case secondarySystemBackground
+    case tertiarySystemBackground
+    
+    case systemGroupedBackground
+    case secondarySystemGroupedBackground
+    case tertiarySystemGroupedBackground
+    
+    var color: UIColor
+    {
+        switch self
+        {
+        case .label:
+            return .label_Adapted
+        case .secondaryLabel:
+            return .secondaryLabel_Adapted
+        case .tertiaryLabel:
+            return .tertiaryLabel_Adapted
+        case .quaternaryLabel:
+            return .quaternaryLabel_Adapted
+        case .placeholderText:
+            return .placeholderText_Adapted
+        case .separator:
+            return .separator_Adapted
+        case .opaqueSeparator:
+            return .opaqueSeparator_Adapted
+        case .link:
+            return .link_Adapted
+            
+        case .systemFill:
+            return .systemFill_Adapted
+        case .secondarySystemFill:
+            return .secondarySystemFill_Adapted
+        case .tertiarySystemFilll:
+            return .tertiarySystemFilll_Adapted
+        case .quaternarySystemFill:
+            return .quaternarySystemFill_Adapted
+            
+        case .systemBackground:
+            return .systemBackground_Adapted
+        case .secondarySystemBackground:
+            return .secondarySystemBackground_Adapted
+        case .tertiarySystemBackground:
+            return .tertiarySystemBackground_Adapted
+            
+        case .systemGroupedBackground:
+            return .systemGroupedBackground_Adapted
+        case .secondarySystemGroupedBackground:
+            return .secondarySystemGroupedBackground_Adapted
+        case .tertiarySystemGroupedBackground:
+            return .tertiarySystemGroupedBackground_Adapted
+        }
+    }
+}

--- a/Tests/DarkModeTests/Helpers/ColorVerifier.swift
+++ b/Tests/DarkModeTests/Helpers/ColorVerifier.swift
@@ -1,0 +1,38 @@
+//
+// ColorVerifier.swift
+// DarkModeTests
+//
+// Copyright © 2022 Mikhail Zhigulin. All rights reserved.
+
+import UIKit
+import XCTest
+@testable import PerseusDarkMode
+@testable import AdaptedSystemUI
+
+final class ColorVerifier
+{
+    class func verify(requirement     : ColorRequirement,
+                      _ requiredLight : UIColor?,
+                      _ requiredDark  : UIColor?,
+                      _ iOS13         : UIColor?,
+                      file            : StaticString = #file,
+                      line            : UInt = #line)
+    {
+        if #available(iOS 13.0, *)
+        {
+            XCTAssertEqual(requirement.color, iOS13)
+        }
+        else
+        {
+            AppearanceService.shared.DarkModeUserChoice = .off
+            AppearanceService.adaptToDarkMode()
+            
+            XCTAssertEqual(requirement.color, requiredLight)
+            
+            AppearanceService.shared.DarkModeUserChoice = .on
+            AppearanceService.adaptToDarkMode()
+            
+            XCTAssertEqual(requirement.color, requiredDark)
+        }
+    }
+}

--- a/Tests/DarkModeTests/SemanticColorsAdaptedTests.swift
+++ b/Tests/DarkModeTests/SemanticColorsAdaptedTests.swift
@@ -1,0 +1,219 @@
+//
+// SemanticColorsAdaptedTests.swift
+// DarkModeTests
+//
+// Copyright © 2022 Mikhail Zhigulin. All rights reserved.
+
+import XCTest
+@testable import PerseusDarkMode
+@testable import AdaptedSystemUI
+
+final class SemanticColorsAdaptedTests: XCTestCase
+{
+    func test_Init()
+    {
+        XCTAssertFalse(AppearanceService.shared.isEnabled)
+    }
+    
+    // MARK: - Tests for Foreground
+    
+    func test_label_Adapted()
+    {
+        let light = rgba255(255, 255, 255)
+        let dark = rgba255(0, 0, 0)
+        
+        if #available(iOS 13.0, *)
+        { ColorVerifier.verify(requirement: .label, nil, nil, .label) }
+        else
+        { ColorVerifier.verify(requirement: .label, light, dark, nil) }
+    }
+    
+    func test_secondaryLabel_Adapted()
+    {
+        let light = rgba255(235, 235, 245, 0.6)
+        let dark = rgba255(60, 60, 67, 0.6)
+        
+        if #available(iOS 13.0, *)
+        { ColorVerifier.verify(requirement: .secondaryLabel, nil, nil, .secondaryLabel) }
+        else
+        { ColorVerifier.verify(requirement: .secondaryLabel, light, dark, nil) }
+    }
+    
+    func test_tertiaryLabel_Adapted()
+    {
+        let light = rgba255(235, 235, 245, 0.3)
+        let dark = rgba255(60, 60, 67, 0.3)
+        
+        if #available(iOS 13.0, *)
+        { ColorVerifier.verify(requirement: .tertiaryLabel, nil, nil, .tertiaryLabel) }
+        else
+        { ColorVerifier.verify(requirement: .tertiaryLabel, light, dark, nil) }
+    }
+    
+    func test_quaternaryLabel_Adapted()
+    {
+        let light = rgba255(235, 235, 245, 0.18)
+        let dark = rgba255(60, 60, 67, 0.18)
+        
+        if #available(iOS 13.0, *)
+        { ColorVerifier.verify(requirement: .quaternaryLabel, nil, nil, .quaternaryLabel) }
+        else
+        { ColorVerifier.verify(requirement: .quaternaryLabel, light, dark, nil) }
+    }
+    
+    func test_placeholderText_Adapted()
+    {
+        let light = rgba255(235, 235, 245, 0.3)
+        let dark = rgba255(60, 60, 67, 0.3)
+        
+        if #available(iOS 13.0, *)
+        { ColorVerifier.verify(requirement: .placeholderText, nil, nil, .placeholderText) }
+        else
+        { ColorVerifier.verify(requirement: .placeholderText, light, dark, nil) }
+    }
+    
+    func test_separator_Adapted()
+    {
+        let light = rgba255(84, 84, 88, 0.6)
+        let dark = rgba255(60, 60, 67, 0.29)
+        
+        if #available(iOS 13.0, *)
+        { ColorVerifier.verify(requirement: .separator, nil, nil, .separator) }
+        else
+        { ColorVerifier.verify(requirement: .separator, light, dark, nil) }
+    }
+    
+    func test_opaqueSeparator_Adapted()
+    {
+        let light = rgba255(56, 56, 58)
+        let dark = rgba255(198, 198, 200)
+        
+        if #available(iOS 13.0, *)
+        { ColorVerifier.verify(requirement: .opaqueSeparator, nil, nil, .opaqueSeparator) }
+        else
+        { ColorVerifier.verify(requirement: .opaqueSeparator, light, dark, nil) }
+    }
+    
+    func test_link_Adapted()
+    {
+        let light = rgba255(9, 132, 255)
+        let dark = rgba255(0, 122, 255)
+        
+        if #available(iOS 13.0, *)
+        { ColorVerifier.verify(requirement: .link, nil, nil, .link) }
+        else
+        { ColorVerifier.verify(requirement: .link, light, dark, nil) }
+    }
+    
+    func test_systemFill_Adapted()
+    {
+        let light = rgba255(120, 120, 128, 0.36)
+        let dark = rgba255(120, 120, 128, 0.2)
+        
+        if #available(iOS 13.0, *)
+        { ColorVerifier.verify(requirement: .systemFill, nil, nil, .systemFill) }
+        else
+        { ColorVerifier.verify(requirement: .systemFill, light, dark, nil) }
+    }
+    
+    func test_secondarySystemFill_Adapted()
+    {
+        let light = rgba255(120, 120, 128, 0.32)
+        let dark = rgba255(120, 120, 128, 0.16)
+        
+        if #available(iOS 13.0, *)
+        { ColorVerifier.verify(requirement: .secondarySystemFill, nil, nil, .secondarySystemFill) }
+        else
+        { ColorVerifier.verify(requirement: .secondarySystemFill, light, dark, nil) }
+    }
+    
+    func test_tertiarySystemFilll_Adapted()
+    {
+        let light = rgba255(118, 118, 128, 0.24)
+        let dark = rgba255(118, 118, 128, 0.12)
+        
+        if #available(iOS 13.0, *)
+        { ColorVerifier.verify(requirement: .tertiarySystemFilll, nil, nil, .tertiarySystemFill) }
+        else
+        { ColorVerifier.verify(requirement: .tertiarySystemFilll, light, dark, nil) }
+    }
+    
+    func test_quaternarySystemFill_Adapted()
+    {
+        let light = rgba255(118, 118, 128, 0.18)
+        let dark = rgba255(116, 116, 128, 0.08)
+        
+        if #available(iOS 13.0, *)
+        { ColorVerifier.verify(requirement: .quaternarySystemFill, nil, nil, .quaternarySystemFill) }
+        else
+        { ColorVerifier.verify(requirement: .quaternarySystemFill, light, dark, nil) }
+    }
+    
+    // MARK: - Tests for Background
+    
+    func test_systemBackground_Adapted()
+    {
+        let light = rgba255(0, 0, 0)
+        let dark = rgba255(255, 255, 255)
+        
+        if #available(iOS 13.0, *)
+        { ColorVerifier.verify(requirement: .systemBackground, nil, nil, .systemBackground) }
+        else
+        { ColorVerifier.verify(requirement: .systemBackground, light, dark, nil) }
+    }
+    
+    func test_secondarySystemBackground_Adapted()
+    {
+        let light = rgba255(28, 28, 30)
+        let dark = rgba255(242, 242, 247)
+        
+        if #available(iOS 13.0, *)
+        { ColorVerifier.verify(requirement: .secondarySystemBackground, nil, nil, .secondarySystemBackground) }
+        else
+        { ColorVerifier.verify(requirement: .secondarySystemBackground, light, dark, nil) }
+    }
+    
+    func test_tertiarySystemBackground_Adapted()
+    {
+        let light = rgba255(44, 44, 46)
+        let dark = rgba255(255, 255, 255)
+        
+        if #available(iOS 13.0, *)
+        { ColorVerifier.verify(requirement: .tertiarySystemBackground, nil, nil, .tertiarySystemBackground) }
+        else
+        { ColorVerifier.verify(requirement: .tertiarySystemBackground, light, dark, nil) }
+    }
+    
+    func test_systemGroupedBackground_Adapted()
+    {
+        let light = rgba255(0, 0, 0)
+        let dark = rgba255(242, 242, 247)
+        
+        if #available(iOS 13.0, *)
+        { ColorVerifier.verify(requirement: .systemGroupedBackground, nil, nil, .systemGroupedBackground) }
+        else
+        { ColorVerifier.verify(requirement: .systemGroupedBackground, light, dark, nil) }
+    }
+    
+    func test_secondarySystemGroupedBackground_Adapted()
+    {
+        let light = rgba255(28, 28, 30)
+        let dark = rgba255(255, 255, 255)
+        
+        if #available(iOS 13.0, *)
+        { ColorVerifier.verify(requirement: .secondarySystemGroupedBackground, nil, nil, .secondarySystemGroupedBackground) }
+        else
+        { ColorVerifier.verify(requirement: .secondarySystemGroupedBackground, light, dark, nil) }
+    }
+    
+    func test_tertiarySystemGroupedBackground_Adapted()
+    {
+        let light = rgba255(44, 44, 46)
+        let dark = rgba255(242, 242, 247)
+        
+        if #available(iOS 13.0, *)
+        { ColorVerifier.verify(requirement: .tertiarySystemGroupedBackground, nil, nil, .tertiarySystemGroupedBackground) }
+        else
+        { ColorVerifier.verify(requirement: .tertiarySystemGroupedBackground, light, dark, nil) }
+    }
+}


### PR DESCRIPTION
A set of adapted semantic colors covered with unit tests.

CHANGED: adopted > adapted

FIXED: ".label_Adapted" color in [SemanticColorsAdapted] file.

IMPROVED: Code readability of colors determining.

ADDED: A set of unit tests to cover semantic colors placed in [SemanticColorsAdapted] file.