### PR TITLE
Unit test for [DarkModeDecision]

### DIFF
--- a/Sources/AdaptedSystemUI/ColorHelper.swift
+++ b/Sources/AdaptedSystemUI/ColorHelper.swift
@@ -4,7 +4,9 @@
 //
 // Copyright © 2022 Mikhail Zhigulin. All rights reserved.
 
+#if !os(macOS)
 import UIKit
+#endif
 
 public func rgba255(_ red  : CGFloat,
                     _ green: CGFloat,

--- a/Sources/AdaptedSystemUI/SemanticColorsAdapted.swift
+++ b/Sources/AdaptedSystemUI/SemanticColorsAdapted.swift
@@ -4,7 +4,10 @@
 //
 // Copyright © 2022 Mikhail Zhigulin. All rights reserved.
 
+#if !os(macOS)
 import UIKit
+#endif
+
 import PerseusDarkMode
 
 // MARK: Semantic colors

--- a/Sources/AdaptedSystemUI/SystemColorsAdapted.swift
+++ b/Sources/AdaptedSystemUI/SystemColorsAdapted.swift
@@ -4,7 +4,10 @@
 //
 // Copyright © 2022 Mikhail Zhigulin. All rights reserved.
 
+#if !os(macOS)
 import UIKit
+#endif
+
 import PerseusDarkMode
 
 // MARK: System colors

--- a/Sources/PerseusDarkMode/AppearanceService/AppearanceService.swift
+++ b/Sources/PerseusDarkMode/AppearanceService/AppearanceService.swift
@@ -4,7 +4,9 @@
 //
 // Copyright © 2022 Mikhail Zhigulin. All rights reserved.
 
+#if !os(macOS)
 import UIKit
+#endif
 
 public protocol AppearanceAdaptableElement
 {
@@ -58,7 +60,7 @@ public class AppearanceService
         
         guard adaptableElements.isEmpty != true else { return }
         
-        // Adopt system controls in according with Dark Mode
+        // Adapt system controls in according with Dark Mode
         
         if #available(iOS 13.0, *),
            let keyWindow = UIApplication.shared.keyWindow
@@ -74,7 +76,7 @@ public class AppearanceService
             }
         }
         
-        // Adopt sibscriber's UI elements in according with Dark Mode
+        // Adapt sibscriber's UI elements in according with Dark Mode
         
         adaptableElements.forEach(
             { item in

--- a/Sources/PerseusDarkMode/DarkMode/DarkMode.swift
+++ b/Sources/PerseusDarkMode/DarkMode/DarkMode.swift
@@ -4,7 +4,9 @@
 //
 // Copyright © 2022 Mikhail Zhigulin. All rights reserved.
 
+#if !os(macOS)
 import UIKit
+#endif
 
 public class DarkMode
 {
@@ -12,7 +14,10 @@ public class DarkMode
     
     public var Style             : AppearanceStyle
     {
-        DarkModeDecision.calculateActualStyle(DarkModeUserChoice)
+        let userChoice = DarkModeUserChoice
+        let systemStyle = DarkModeDecision.calculateSystemStyle()
+        
+        return DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
     }
     
     public var isEnabled         : Bool = false { willSet { if newValue == false { return } } }

--- a/Sources/PerseusDarkMode/DarkMode/DarkModeDecision.swift
+++ b/Sources/PerseusDarkMode/DarkMode/DarkModeDecision.swift
@@ -4,7 +4,9 @@
 //
 // Copyright © 2022 Mikhail Zhigulin. All rights reserved.
 
+#if !os(macOS)
 import UIKit
+#endif
 
 // MARK: - Calculations
 
@@ -26,13 +28,9 @@ public class DarkModeDecision
     /// System style  .dark                         dark              dark              light
     /// — — — — — — — — — — — — — — — — — — — — — — — — —
     ///
-    public class func calculateActualStyle(_ userChoice: DarkModeOption) -> AppearanceStyle
+    public class func calculateActualStyle(_ userChoice : DarkModeOption,
+                                           _ systemStyle: SystemStyle) -> AppearanceStyle
     {
-        // Inputs
-        
-        let userChoice = userChoice
-        let systemStyle = calculateSystemStyle()
-        
         // Calculate outputs
         
         if (systemStyle == .unspecified) && (userChoice == .auto)

--- a/Sources/PerseusDarkMode/SetupByDefault.swift
+++ b/Sources/PerseusDarkMode/SetupByDefault.swift
@@ -4,7 +4,9 @@
 //
 // Copyright © 2022 Mikhail Zhigulin. All rights reserved.
 
+#if !os(macOS)
 import UIKit
+#endif
 
 public extension UIViewController { var DarkMode: DarkMode { AppearanceService.shared } }
 public extension UIView { var DarkMode: DarkMode { AppearanceService.shared } }

--- a/Tests/DarkModeTests/DarkModeDecisionTests.swift
+++ b/Tests/DarkModeTests/DarkModeDecisionTests.swift
@@ -1,0 +1,169 @@
+//
+// DarkModeDecisionTests.swift
+// DarkModeTests
+//
+// Copyright © 2022 Mikhail Zhigulin. All rights reserved.
+
+#if !os(macOS)
+import UIKit
+#endif
+
+import XCTest
+@testable import PerseusDarkMode
+
+final class DarkModeDecisionTests: XCTestCase
+{
+    /// Decision table for Actual Style
+    ///
+    /// — — — — — — — — — — — — — — DarkModeOption — — — — —
+    /// — — — — — — — — — — — — auto — — — on — — — — off  — —
+    /// — — — — — — — — — — — — — — — — — — — — — — — — —
+    /// System style  .unspecified            default            dark              light
+    /// System style  .light                         light               dark              light
+    /// System style  .dark                         dark              dark              light
+    /// — — — — — — — — — — — — — — — — — — — — — — — — —
+    ///
+    func test_calculateActualStyle_with_auto_and_unspecified_should_return_default()
+    {
+        // arrange
+        
+        let userChoice = DarkModeOption.auto
+        let systemStyle = SystemStyle.unspecified
+        
+        // act
+        
+        let result = DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        
+        // assert
+        
+        XCTAssertEqual(result, DARK_MODE_STYLE_DEFAULT)
+    }
+    
+    func test_calculateActualStyle_with_on_and_unspecified_should_return_dark()
+    {
+        // arrange
+        
+        let userChoice = DarkModeOption.on
+        let systemStyle = SystemStyle.unspecified
+        
+        // act
+        
+        let result = DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        
+        // assert
+        
+        XCTAssertEqual(result, .dark)
+    }
+    
+    func test_calculateActualStyle_with_off_and_unspecified_should_return_light()
+    {
+        // arrange
+        
+        let userChoice = DarkModeOption.off
+        let systemStyle = SystemStyle.unspecified
+        
+        // act
+        
+        let result = DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        
+        // assert
+        
+        XCTAssertEqual(result, .light)
+    }
+    
+    func test_calculateActualStyle_with_auto_and_light_should_return_light()
+    {
+        // arrange
+        
+        let userChoice = DarkModeOption.auto
+        let systemStyle = SystemStyle.light
+        
+        // act
+        
+        let result = DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        
+        // assert
+        
+        XCTAssertEqual(result, .light)
+    }
+    
+    func test_calculateActualStyle_with_on_and_light_should_return_dark()
+    {
+        // arrange
+        
+        let userChoice = DarkModeOption.on
+        let systemStyle = SystemStyle.light
+        
+        // act
+        
+        let result = DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        
+        // assert
+        
+        XCTAssertEqual(result, .dark)
+    }
+    
+    func test_calculateActualStyle_with_off_and_light_should_return_light()
+    {
+        // arrange
+        
+        let userChoice = DarkModeOption.off
+        let systemStyle = SystemStyle.light
+        
+        // act
+        
+        let result = DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        
+        // assert
+        
+        XCTAssertEqual(result, .light)
+    }
+    
+    func test_calculateActualStyle_with_auto_and_dark_should_return_dark()
+    {
+        // arrange
+        
+        let userChoice = DarkModeOption.auto
+        let systemStyle = SystemStyle.dark
+        
+        // act
+        
+        let result = DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        
+        // assert
+        
+        XCTAssertEqual(result, .dark)
+    }
+    
+    func test_calculateActualStyle_with_on_and_dark_should_return_dark()
+    {
+        // arrange
+        
+        let userChoice = DarkModeOption.on
+        let systemStyle = SystemStyle.dark
+        
+        // act
+        
+        let result = DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        
+        // assert
+        
+        XCTAssertEqual(result, .dark)
+    }
+    
+    func test_calculateActualStyle_with_off_and_dark_should_return_light()
+    {
+        // arrange
+        
+        let userChoice = DarkModeOption.off
+        let systemStyle = SystemStyle.dark
+        
+        // act
+        
+        let result = DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        
+        // assert
+        
+        XCTAssertEqual(result, .light)
+    }
+}

--- a/Tests/DarkModeTests/DarkModeTests.swift
+++ b/Tests/DarkModeTests/DarkModeTests.swift
@@ -4,6 +4,10 @@
 //
 // Copyright © 2022 Mikhail Zhigulin. All rights reserved.
 
+#if !os(macOS)
+import UIKit
+#endif
+
 import XCTest
 @testable import PerseusDarkMode
 @testable import AdaptedSystemUI
@@ -13,6 +17,10 @@ final class DarkModeTests: XCTestCase
     func test_Init()
     {
         XCTAssertFalse(AppearanceService.shared.isEnabled)
+        
+        XCTAssertIdentical(UIView().DarkMode, AppearanceService.shared)
+        XCTAssertIdentical(UIViewController().DarkMode, AppearanceService.shared)
+        
+        XCTAssertIdentical(AppearanceService.shared.userDefaults, UserDefaults.standard)
     }
 }
-

--- a/Tests/DarkModeTests/Helpers/ColorRequirement.swift
+++ b/Tests/DarkModeTests/Helpers/ColorRequirement.swift
@@ -4,7 +4,10 @@
 //
 // Copyright © 2022 Mikhail Zhigulin. All rights reserved.
 
+#if !os(macOS)
 import UIKit
+#endif
+
 @testable import AdaptedSystemUI
 
 enum ColorRequirement

--- a/Tests/DarkModeTests/Helpers/ColorVerifier.swift
+++ b/Tests/DarkModeTests/Helpers/ColorVerifier.swift
@@ -4,7 +4,10 @@
 //
 // Copyright © 2022 Mikhail Zhigulin. All rights reserved.
 
+#if !os(macOS)
 import UIKit
+#endif
+
 import XCTest
 @testable import PerseusDarkMode
 @testable import AdaptedSystemUI

--- a/Tests/DarkModeTests/SemanticColorsAdaptedTests.swift
+++ b/Tests/DarkModeTests/SemanticColorsAdaptedTests.swift
@@ -10,11 +10,6 @@ import XCTest
 
 final class SemanticColorsAdaptedTests: XCTestCase
 {
-    func test_Init()
-    {
-        XCTAssertFalse(AppearanceService.shared.isEnabled)
-    }
-    
     // MARK: - Tests for Foreground
     
     func test_label_Adapted()


### PR DESCRIPTION
A set of unit tests was included to cover [DarkModeDecision].

CHANGED: The method signature of [DarkModeDecision] API.

CHANGED: Spelling adopt > adapt.

ADDED: The compiler directive #if !os(macOS) to satisfy compiler warnings.