### PR TITLE
Unit test for [AppearanceService]

### DIFF
--- a/Sources/PerseusDarkMode/AppearanceService/AppearanceService.swift
+++ b/Sources/PerseusDarkMode/AppearanceService/AppearanceService.swift
@@ -44,7 +44,7 @@ public class AppearanceService
     
     // MARK: - Public API: register subscriber
     
-    static func register(observer: Any, selector: Selector)
+    public static func register(observer: Any, selector: Selector)
     {
         #if DEBUG
         print(">> [\(type(of: self))]." + #function)
@@ -58,7 +58,7 @@ public class AppearanceService
     
     // MARK: - Public API: call each subscriber to adapt appearance
     
-    public static func makeAppearanceUp()
+    public static func makeUp()
     {
         _isEnabled = true
         

--- a/Sources/PerseusDarkMode/AppearanceService/AppearanceService.swift
+++ b/Sources/PerseusDarkMode/AppearanceService/AppearanceService.swift
@@ -8,13 +8,25 @@
 import UIKit
 #endif
 
-public protocol AppearanceAdaptableElement
+public extension Notification.Name
 {
-    func adaptAppearance()
+    static let makeAppearanceUpStatement = Notification.Name("makeAppearanceUpStatement")
 }
 
 public class AppearanceService
 {
+    // MARK: - Properties
+    
+    public static var isEnabled       : Bool { _isEnabled }
+    
+    private(set) static var _isEnabled: Bool = false { willSet { if newValue == false { return }}}
+    
+    #if DEBUG // Isolated for unit testing
+    static var nCenter: NotificationCenterProtocol = NotificationCenter.default
+    #else
+    private(set) static var nCenter = NotificationCenter.default
+    #endif
+    
     // MARK: - Singleton
     
     public static var shared: DarkMode =
@@ -30,35 +42,25 @@ public class AppearanceService
     
     private init() { }
     
-    // MARK: - Subscribers
-    
-    private static var adaptableElements = Set<UIResponder>()
-    
     // MARK: - Public API: register subscriber
     
-    public static func register(_ screenElement: AppearanceAdaptableElement)
+    static func register(observer: Any, selector: Selector)
     {
-        guard let element = screenElement as? UIResponder else { return }
+        #if DEBUG
+        print(">> [\(type(of: self))]." + #function)
+        #endif
         
-        adaptableElements.insert(element)
-    }
-    
-    // MARK: - Public API: unregister subscriber
-    
-    public static func unregister(_ screenElement: AppearanceAdaptableElement)
-    {
-        guard let element = screenElement as? UIResponder else { return }
-        
-        adaptableElements.remove(element)
+        nCenter.addObserver(observer,
+                            selector: selector,
+                            name    : .makeAppearanceUpStatement,
+                            object  : nil)
     }
     
     // MARK: - Public API: call each subscriber to adapt appearance
     
-    public static func adaptToDarkMode()
+    public static func makeAppearanceUp()
     {
-        shared.isEnabled = true
-        
-        guard adaptableElements.isEmpty != true else { return }
+        _isEnabled = true
         
         // Adapt system controls in according with Dark Mode
         
@@ -76,15 +78,22 @@ public class AppearanceService
             }
         }
         
-        // Adapt sibscriber's UI elements in according with Dark Mode
+        // Tell the others to make appearance up
         
-        adaptableElements.forEach(
-            { item in
-                
-                if let element = item as? AppearanceAdaptableElement
-                {
-                    element.adaptAppearance()
-                }
-            })
+        nCenter.post(name: .makeAppearanceUpStatement, object: nil)
     }
 }
+
+// MARK: Protocols used for unit testing
+
+protocol NotificationCenterProtocol
+{
+    func addObserver(_ observer        : Any,
+                     selector aSelector: Selector,
+                     name aName        : NSNotification.Name?,
+                     object anObject   : Any?)
+    
+    func post(name aName: NSNotification.Name, object anObject: Any?)
+}
+
+extension NotificationCenter: NotificationCenterProtocol { }

--- a/Sources/PerseusDarkMode/DarkMode/DarkMode.swift
+++ b/Sources/PerseusDarkMode/DarkMode/DarkMode.swift
@@ -20,8 +20,6 @@ public class DarkMode
         return DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
     }
     
-    public var isEnabled         : Bool = false { willSet { if newValue == false { return } } }
-    
     // MARK: - Dark Mode Style saved in UserDafaults
     
     public var userDefaults      : UserDefaults?

--- a/Sources/PerseusDarkMode/DarkMode/DarkModeDecision.swift
+++ b/Sources/PerseusDarkMode/DarkMode/DarkModeDecision.swift
@@ -37,16 +37,16 @@ public class DarkModeDecision
         {
             return DARK_MODE_STYLE_DEFAULT
         }
-        if (systemStyle == .unspecified) && (userChoice == .on) { return .dark}
-        if (systemStyle == .unspecified) && (userChoice == .off) { return .light}
+        if (systemStyle == .unspecified) && (userChoice == .on) { return .dark }
+        if (systemStyle == .unspecified) && (userChoice == .off) { return .light }
         
         if (systemStyle == .light) && (userChoice == .auto) { return .light }
-        if (systemStyle == .light) && (userChoice == .on) { return .dark}
-        if (systemStyle == .light) && (userChoice == .off) { return .light}
+        if (systemStyle == .light) && (userChoice == .on) { return .dark }
+        if (systemStyle == .light) && (userChoice == .off) { return .light }
         
         if (systemStyle == .dark) && (userChoice == .auto) { return .dark }
-        if (systemStyle == .dark) && (userChoice == .on) { return .dark}
-        if (systemStyle == .dark) && (userChoice == .off) { return .light}
+        if (systemStyle == .dark) && (userChoice == .on) { return .dark }
+        if (systemStyle == .dark) && (userChoice == .off) { return .light }
         
         // Output default value if somethings goes out of the decision table
         

--- a/Sources/PerseusDarkMode/SetupByDefault.swift
+++ b/Sources/PerseusDarkMode/SetupByDefault.swift
@@ -21,7 +21,7 @@ public class UIWindowAdaptable: UIWindow
             previousSystemStyle.rawValue != DarkModeDecision.calculateSystemStyle().rawValue
         else { return }
         
-        AppearanceService.makeAppearanceUp()
+        AppearanceService.makeUp()
     }
 }
 

--- a/Sources/PerseusDarkMode/SetupByDefault.swift
+++ b/Sources/PerseusDarkMode/SetupByDefault.swift
@@ -21,7 +21,7 @@ public class UIWindowAdaptable: UIWindow
             previousSystemStyle.rawValue != DarkModeDecision.calculateSystemStyle().rawValue
         else { return }
         
-        AppearanceService.adaptToDarkMode()
+        AppearanceService.makeAppearanceUp()
     }
 }
 

--- a/Tests/DarkModeTests/AppearanceServiceTests.swift
+++ b/Tests/DarkModeTests/AppearanceServiceTests.swift
@@ -53,7 +53,7 @@ final class AppearanceServiceTests: XCTestCase
         
         // act
         
-        AppearanceService.makeAppearanceUp()
+        AppearanceService.makeUp()
         
         // assert
         

--- a/Tests/DarkModeTests/AppearanceServiceTests.swift
+++ b/Tests/DarkModeTests/AppearanceServiceTests.swift
@@ -1,0 +1,63 @@
+//
+// AppearanceServiceTests.swift
+// DarkModeTests
+//
+// Copyright © 2022 Mikhail Zhigulin. All rights reserved.
+
+#if !os(macOS)
+import UIKit
+#endif
+
+import XCTest
+@testable import PerseusDarkMode
+
+final class AppearanceServiceTests: XCTestCase
+{
+    func test_init()
+    {
+        XCTAssertFalse(AppearanceService.isEnabled)
+        XCTAssertFalse(AppearanceService._isEnabled)
+        
+        XCTAssertNotNil(AppearanceService.shared.userDefaults)
+        XCTAssertNotNil(AppearanceService.nCenter)
+        
+        XCTAssertIdentical(UIView().DarkMode, AppearanceService.shared)
+        XCTAssertIdentical(UIViewController().DarkMode, AppearanceService.shared)
+    }
+    
+    func test_method_register_called_addObserver()
+    {
+        // arrange
+        
+        let mock = MockNotificationCenter()
+        AppearanceService.nCenter = mock
+        
+        class MyView: UIView { @objc func test() { } }
+        let view = MyView()
+        
+        // act
+        
+        AppearanceService.register(observer: view, selector: #selector(view.test))
+        
+        // assert
+        
+        mock.verifyRegisterObserver(observer: view, selector: #selector(view.test))
+    }
+    
+    func test_method_makeAppearanceUp_called_post_and_isEnabled_true()
+    {
+        // arrange
+        
+        let mock = MockNotificationCenter()
+        AppearanceService.nCenter = mock
+        
+        // act
+        
+        AppearanceService.makeAppearanceUp()
+        
+        // assert
+        
+        mock.verifyPost(name: .makeAppearanceUpStatement)
+        XCTAssertTrue(AppearanceService.isEnabled)
+    }
+}

--- a/Tests/DarkModeTests/DarkModeTests.swift
+++ b/Tests/DarkModeTests/DarkModeTests.swift
@@ -10,17 +10,13 @@ import UIKit
 
 import XCTest
 @testable import PerseusDarkMode
-@testable import AdaptedSystemUI
 
 final class DarkModeTests: XCTestCase
 {
-    func test_Init()
+    func test_init()
     {
-        XCTAssertFalse(AppearanceService.shared.isEnabled)
+        let sut = DarkMode()
         
-        XCTAssertIdentical(UIView().DarkMode, AppearanceService.shared)
-        XCTAssertIdentical(UIViewController().DarkMode, AppearanceService.shared)
-        
-        XCTAssertIdentical(AppearanceService.shared.userDefaults, UserDefaults.standard)
+        XCTAssertNil(sut.userDefaults)
     }
 }

--- a/Tests/DarkModeTests/Helpers/ColorVerifier.swift
+++ b/Tests/DarkModeTests/Helpers/ColorVerifier.swift
@@ -14,12 +14,12 @@ import XCTest
 
 final class ColorVerifier
 {
-    class func verify(requirement     : ColorRequirement,
-                      _ requiredLight : UIColor?,
-                      _ requiredDark  : UIColor?,
-                      _ iOS13         : UIColor?,
-                      file            : StaticString = #file,
-                      line            : UInt = #line)
+    class func verify(requirement    : ColorRequirement,
+                      _ requiredLight: UIColor?,
+                      _ requiredDark : UIColor?,
+                      _ iOS13        : UIColor?,
+                      file           : StaticString = #file,
+                      line           : UInt = #line)
     {
         if #available(iOS 13.0, *), iOS13 != nil
         {
@@ -28,12 +28,12 @@ final class ColorVerifier
         else
         {
             AppearanceService.shared.DarkModeUserChoice = .off
-            AppearanceService.adaptToDarkMode()
+            AppearanceService.makeAppearanceUp()
             
             XCTAssertEqual(requirement.color, requiredLight)
             
             AppearanceService.shared.DarkModeUserChoice = .on
-            AppearanceService.adaptToDarkMode()
+            AppearanceService.makeAppearanceUp()
             
             XCTAssertEqual(requirement.color, requiredDark)
         }

--- a/Tests/DarkModeTests/Helpers/ColorVerifier.swift
+++ b/Tests/DarkModeTests/Helpers/ColorVerifier.swift
@@ -28,12 +28,12 @@ final class ColorVerifier
         else
         {
             AppearanceService.shared.DarkModeUserChoice = .off
-            AppearanceService.makeAppearanceUp()
+            AppearanceService.makeUp()
             
             XCTAssertEqual(requirement.color, requiredLight)
             
             AppearanceService.shared.DarkModeUserChoice = .on
-            AppearanceService.makeAppearanceUp()
+            AppearanceService.makeUp()
             
             XCTAssertEqual(requirement.color, requiredDark)
         }

--- a/Tests/DarkModeTests/Helpers/MockNotificationCenter.swift
+++ b/Tests/DarkModeTests/Helpers/MockNotificationCenter.swift
@@ -1,0 +1,107 @@
+//
+//  MockNotificationCenter.swift
+// DarkModeTests
+//
+// Copyright © 2022 Mikhail Zhigulin. All rights reserved.
+
+#if !os(macOS)
+import UIKit
+#endif
+
+import XCTest
+@testable import PerseusDarkMode
+
+class MockNotificationCenter: NotificationCenterProtocol
+{
+    // MARK: - addObserver
+    
+    var registerCallCount = 0
+    var registerArgs_observers : [UIResponder] = []
+    var registerArgs_selectors: [Selector] = []
+    
+    func addObserver(_ observer        : Any,
+                     selector aSelector: Selector,
+                     name aName        : NSNotification.Name?,
+                     object anObject   : Any?)
+    {
+        registerCallCount += 1
+        
+        registerArgs_observers.append(observer as! UIResponder)
+        registerArgs_selectors.append(aSelector)
+    }
+    
+    func verifyRegisterObserver(observer: UIResponder,
+                                selector: Selector,
+                                file    : StaticString = #file,
+                                line    : UInt = #line)
+    {
+        guard registerWasCalledOnce(file: file, line: line) else { return }
+        
+        XCTAssertTrue(registerArgs_observers.first! === observer,
+                      "observer", file: file, line: line)
+        
+        XCTAssertEqual(registerArgs_selectors.first, selector,
+                       "selector", file: file, line: line)
+    }
+    
+    private func registerWasCalledOnce(file: StaticString = #file, line: UInt = #line) -> Bool
+    {
+        verifyMethodCalledOnce(
+            methodName       : "register",
+            callCount        : registerCallCount,
+            describeArguments: "name: \(registerArgs_selectors)",
+            file             : file,
+            line             : line)
+    }
+    
+    // MARK: - post
+    
+    var postCallCount = 0
+    var postrgs_names : [String] = []
+    
+    func post(name aName: NSNotification.Name, object anObject: Any?)
+    {
+        postCallCount += 1
+        postrgs_names.append(aName.rawValue)
+    }
+    
+    func verifyPost(name: NSNotification.Name,
+                    file: StaticString = #file,
+                    line: UInt = #line)
+    {
+        guard postWasCalledOnce(file: file, line: line) else { return }
+        
+        XCTAssertTrue(postrgs_names.first! == name.rawValue, "name", file: file, line: line)
+    }
+    
+    private func postWasCalledOnce(file: StaticString = #file, line: UInt = #line) -> Bool
+    {
+        verifyMethodCalledOnce(
+            methodName       : "post",
+            callCount        : postCallCount,
+            describeArguments: "name: \(postrgs_names)",
+            file             : file,
+            line             : line)
+    }
+}
+
+fileprivate func verifyMethodCalledOnce(methodName       : String, callCount: Int,
+                                        describeArguments: @autoclosure () -> String,
+                                        file             : StaticString = #file,
+                                        line             : UInt = #line) -> Bool
+{
+    if callCount == 0
+    {
+        XCTFail("Wanted but not invoked: \(methodName)", file: file, line: line)
+        return false
+    }
+    
+    if callCount > 1
+    {
+        XCTFail("Wanted 1 time but was called \(callCount) times. " +
+                    "\(methodName) with \(describeArguments())", file: file, line: line)
+        return false
+    }
+    
+    return true
+}


### PR DESCRIPTION
A set of unit tests was included to cover [AppearanceService].

REFACTORED: One-to-many notification engine of [AppearanceService].

Apple Notification Center is in use now.

MOVED: Flag isEnabled from [DarkMode] to [AppearanceService].

CHANGED: The method signature name of [AppearanceService] API from adaptToDarkMode to makeUp.