### PR TITLE
Unit test for [DarkMode]

### DIFF
--- a/Sources/PerseusDarkMode/DarkMode/DarkMode.swift
+++ b/Sources/PerseusDarkMode/DarkMode/DarkMode.swift
@@ -12,23 +12,22 @@ public class DarkMode: NSObject
 {
     // MARK: - App's Dark Mode Style
     
-    internal var _style = DARK_MODE_STYLE_DEFAULT
+    internal var _style                     :AppearanceStyle = DARK_MODE_STYLE_DEFAULT
     {
-        didSet
-        {
-            StyleObservable = Style.rawValue
-        }
+        didSet { StyleObservable = Style.rawValue }
     }
     
-    public var Style: AppearanceStyle { _style }
+    /// Actual the app's Dark Mode style value, available only for reading
+    public var Style                        : AppearanceStyle { _style }
     
     // MARK: - Observable Dark Mode Value (Using Key-Value Observing)
     
+    /// Triggers if Style is changed, use KVO to be notified immediately
     @objc public dynamic var StyleObservable: Int = DARK_MODE_STYLE_DEFAULT.rawValue
     
     // MARK: - System's Dark Mode Style
     
-    public var SystemStyle: SystemStyle
+    public var SystemStyle                  : SystemStyle
     {
         if #available(iOS 13.0, *)
         {

--- a/Sources/PerseusDarkMode/DarkMode/DarkMode.swift
+++ b/Sources/PerseusDarkMode/DarkMode/DarkMode.swift
@@ -8,45 +8,48 @@
 import UIKit
 #endif
 
-public class DarkMode
+public class DarkMode: NSObject
 {
-    // MARK: - Dark Mode Style
+    // MARK: - App's Dark Mode Style
     
-    public var Style             : AppearanceStyle
+    internal var _style = DARK_MODE_STYLE_DEFAULT
     {
-        let userChoice = DarkModeUserChoice
-        let systemStyle = DarkModeDecision.calculateSystemStyle()
-        
-        return DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        didSet
+        {
+            StyleObservable = Style.rawValue
+        }
     }
     
-    // MARK: - Dark Mode Style saved in UserDafaults
+    public var Style: AppearanceStyle { _style }
     
-    public var userDefaults      : UserDefaults?
+    // MARK: - Observable Dark Mode Value (Using Key-Value Observing)
     
-    public var DarkModeUserChoice: DarkModeOption
+    @objc public dynamic var StyleObservable: Int = DARK_MODE_STYLE_DEFAULT.rawValue
+    
+    // MARK: - System's Dark Mode Style
+    
+    public var SystemStyle: SystemStyle
     {
-        get
+        if #available(iOS 13.0, *)
         {
-            guard let ud = userDefaults else { return DARK_MODE_USER_CHOICE_DEFAULT }
+            guard let keyWindow = UIApplication.shared.keyWindow else { return .unspecified }
             
-            // load enum int value
-            
-            let rawValue = ud.valueExists(forKey: DARK_MODE_USER_CHOICE_OPTION_KEY) ?
-                ud.integer(forKey: DARK_MODE_USER_CHOICE_OPTION_KEY) :
-                DARK_MODE_USER_CHOICE_DEFAULT.rawValue
-            
-            // try to cast int value to enum
-            
-            if let result = DarkModeOption.init(rawValue: rawValue) { return result }
-            
-            return DARK_MODE_USER_CHOICE_DEFAULT
+            switch keyWindow.traitCollection.userInterfaceStyle
+            {
+            case .unspecified:
+                return .unspecified
+            case .light:
+                return .light
+            case .dark:
+                return .dark
+                
+            @unknown default:
+                return .unspecified
+            }
         }
-        set
+        else
         {
-            guard let ud = userDefaults else { return }
-            
-            ud.setValue(newValue.rawValue, forKey: DARK_MODE_USER_CHOICE_OPTION_KEY)
+            return .unspecified
         }
     }
 }

--- a/Sources/PerseusDarkMode/DarkMode/DarkModeDecision.swift
+++ b/Sources/PerseusDarkMode/DarkMode/DarkModeDecision.swift
@@ -28,8 +28,8 @@ public class DarkModeDecision
     /// System style  .dark                         dark              dark              light
     /// — — — — — — — — — — — — — — — — — — — — — — — — —
     ///
-    public class func calculateActualStyle(_ userChoice : DarkModeOption,
-                                           _ systemStyle: SystemStyle) -> AppearanceStyle
+    public class func calculate(_ userChoice : DarkModeOption,
+                                _ systemStyle: SystemStyle) -> AppearanceStyle
     {
         // Calculate outputs
         
@@ -51,30 +51,5 @@ public class DarkModeDecision
         // Output default value if somethings goes out of the decision table
         
         return DARK_MODE_STYLE_DEFAULT
-    }
-    
-    public class func calculateSystemStyle() -> SystemStyle
-    {
-        if #available(iOS 13.0, *)
-        {
-            guard let keyWindow = UIApplication.shared.keyWindow else { return .unspecified }
-            
-            switch keyWindow.traitCollection.userInterfaceStyle
-            {
-            case .unspecified:
-                return .unspecified
-            case .light:
-                return .light
-            case .dark:
-                return .dark
-                
-            @unknown default:
-                return .unspecified
-            }
-        }
-        else
-        {
-            return .unspecified
-        }
     }
 }

--- a/Sources/PerseusDarkMode/DarkMode/DarkModeObserver.swift
+++ b/Sources/PerseusDarkMode/DarkMode/DarkModeObserver.swift
@@ -1,0 +1,43 @@
+//
+// DarkModeObserver.swift
+// PerseusDarkMode
+//
+// Copyright © 2022 Mikhail Zhigulin. All rights reserved.
+
+#if !os(macOS)
+import UIKit
+#endif
+
+public class DarkModeObserver: NSObject
+{
+    public var action         : ((_ newStyle: AppearanceStyle?)->Void)?
+    public let objectToObserve: DarkMode
+    
+    public init(_ value: DarkMode)
+    {
+        objectToObserve = value
+        super.init()
+        
+        objectToObserve.addObserver(self,
+                                    forKeyPath: "StyleObservable",
+                                    options   : .new,
+                                    context   : nil)
+    }
+    
+    public override func observeValue(forKeyPath keyPath: String?,
+                                      of object         : Any?,
+                                      change            : [NSKeyValueChangeKey : Any]?,
+                                      context           : UnsafeMutableRawPointer?)
+    {
+        if keyPath == "StyleObservable",
+           let style = change?[.newKey]
+        {
+            action?(AppearanceStyle.init(rawValue: style as! Int))
+        }
+    }
+    
+    deinit
+    {
+        objectToObserve.removeObserver(self, forKeyPath: "StyleObservable")
+    }
+}

--- a/Sources/PerseusDarkMode/SetupByDefault.swift
+++ b/Sources/PerseusDarkMode/SetupByDefault.swift
@@ -8,8 +8,15 @@
 import UIKit
 #endif
 
-public extension UIViewController { var DarkMode: DarkMode { AppearanceService.shared } }
-public extension UIView { var DarkMode: DarkMode { AppearanceService.shared } }
+public extension UIViewController
+{
+    @objc dynamic var DarkMode: DarkMode { AppearanceService.shared }
+}
+
+public extension UIView
+{
+    @objc dynamic var DarkMode: DarkMode { AppearanceService.shared }
+}
 
 public class UIWindowAdaptable: UIWindow
 {
@@ -18,8 +25,13 @@ public class UIWindowAdaptable: UIWindow
         guard
             #available(iOS 13.0, *),
             let previousSystemStyle = previousTraitCollection?.userInterfaceStyle,
-            previousSystemStyle.rawValue != DarkModeDecision.calculateSystemStyle().rawValue
+            previousSystemStyle.rawValue != DarkMode.SystemStyle.rawValue
         else { return }
+        
+        let userChoice = AppearanceService.DarkModeUserChoice
+        let systemStyle = AppearanceService.shared.SystemStyle
+        
+        AppearanceService.shared._style = DarkModeDecision.calculate(userChoice, systemStyle)
         
         AppearanceService.makeUp()
     }

--- a/Sources/PerseusDarkMode/SetupByDefault.swift
+++ b/Sources/PerseusDarkMode/SetupByDefault.swift
@@ -8,15 +8,8 @@
 import UIKit
 #endif
 
-public extension UIViewController
-{
-    @objc dynamic var DarkMode: DarkMode { AppearanceService.shared }
-}
-
-public extension UIView
-{
-    @objc dynamic var DarkMode: DarkMode { AppearanceService.shared }
-}
+public extension UIViewController { var DarkMode: DarkMode { AppearanceService.shared } }
+public extension UIView { var DarkMode: DarkMode { AppearanceService.shared } }
 
 public class UIWindowAdaptable: UIWindow
 {
@@ -28,12 +21,7 @@ public class UIWindowAdaptable: UIWindow
             previousSystemStyle.rawValue != DarkMode.SystemStyle.rawValue
         else { return }
         
-        let userChoice = AppearanceService.DarkModeUserChoice
-        let systemStyle = AppearanceService.shared.SystemStyle
-        
-        AppearanceService.shared._style = DarkModeDecision.calculate(userChoice, systemStyle)
-        
-        AppearanceService.makeUp()
+        AppearanceService.updateStyle()
     }
 }
 
@@ -41,7 +29,7 @@ public class UIWindowAdaptable: UIWindow
 
 extension UserDefaults
 {
-    func valueExists(forKey key: String) -> Bool
+    public func valueExists(forKey key: String) -> Bool
     {
         return object(forKey: key) != nil
     }

--- a/Tests/DarkModeTests/AppearanceServiceTests.swift
+++ b/Tests/DarkModeTests/AppearanceServiceTests.swift
@@ -18,7 +18,7 @@ final class AppearanceServiceTests: XCTestCase
         XCTAssertFalse(AppearanceService.isEnabled)
         XCTAssertFalse(AppearanceService._isEnabled)
         
-        XCTAssertNotNil(AppearanceService.shared.userDefaults)
+        XCTAssertNotNil(AppearanceService.ud)
         XCTAssertNotNil(AppearanceService.nCenter)
         
         XCTAssertIdentical(UIView().DarkMode, AppearanceService.shared)

--- a/Tests/DarkModeTests/DarkModeDecisionTests.swift
+++ b/Tests/DarkModeTests/DarkModeDecisionTests.swift
@@ -32,7 +32,7 @@ final class DarkModeDecisionTests: XCTestCase
         
         // act
         
-        let result = DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        let result = DarkModeDecision.calculate(userChoice, systemStyle)
         
         // assert
         
@@ -48,7 +48,7 @@ final class DarkModeDecisionTests: XCTestCase
         
         // act
         
-        let result = DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        let result = DarkModeDecision.calculate(userChoice, systemStyle)
         
         // assert
         
@@ -64,7 +64,7 @@ final class DarkModeDecisionTests: XCTestCase
         
         // act
         
-        let result = DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        let result = DarkModeDecision.calculate(userChoice, systemStyle)
         
         // assert
         
@@ -80,7 +80,7 @@ final class DarkModeDecisionTests: XCTestCase
         
         // act
         
-        let result = DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        let result = DarkModeDecision.calculate(userChoice, systemStyle)
         
         // assert
         
@@ -96,7 +96,7 @@ final class DarkModeDecisionTests: XCTestCase
         
         // act
         
-        let result = DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        let result = DarkModeDecision.calculate(userChoice, systemStyle)
         
         // assert
         
@@ -112,7 +112,7 @@ final class DarkModeDecisionTests: XCTestCase
         
         // act
         
-        let result = DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        let result = DarkModeDecision.calculate(userChoice, systemStyle)
         
         // assert
         
@@ -128,7 +128,7 @@ final class DarkModeDecisionTests: XCTestCase
         
         // act
         
-        let result = DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        let result = DarkModeDecision.calculate(userChoice, systemStyle)
         
         // assert
         
@@ -144,7 +144,7 @@ final class DarkModeDecisionTests: XCTestCase
         
         // act
         
-        let result = DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        let result = DarkModeDecision.calculate(userChoice, systemStyle)
         
         // assert
         
@@ -160,7 +160,7 @@ final class DarkModeDecisionTests: XCTestCase
         
         // act
         
-        let result = DarkModeDecision.calculateActualStyle(userChoice, systemStyle)
+        let result = DarkModeDecision.calculate(userChoice, systemStyle)
         
         // assert
         

--- a/Tests/DarkModeTests/DarkModeTests.swift
+++ b/Tests/DarkModeTests/DarkModeTests.swift
@@ -65,6 +65,7 @@ final class DarkModeTests: XCTestCase
             }
         
         // act
+        
         observer = nil
         
         AppearanceService.shared._style = AppearanceStyle.dark
@@ -74,5 +75,74 @@ final class DarkModeTests: XCTestCase
         
         XCTAssertEqual(count, 0)
         XCTAssertEqual(collection, [])
+    }
+    
+    func test_get_DarkModeUserChoice_when_valueExists_true()
+    {
+        // arrange
+        
+        let mockUserDefaults = MockUserDefaults()
+        AppearanceService.ud = mockUserDefaults
+        
+        mockUserDefaults.isValueExists = true
+        
+        // act
+        
+        let _ = AppearanceService.DarkModeUserChoice
+        
+        // assert
+        
+        mockUserDefaults.verifyInterger(name: DARK_MODE_USER_CHOICE_OPTION_KEY)
+        
+        // keep it clean for the others
+        
+        AppearanceService.ud = UserDefaults.standard
+    }
+    
+    func test_get_DarkModeUserChoice_when_valueExists_false()
+    {
+        // arrange
+        
+        let mockUserDefaults = MockUserDefaults()
+        AppearanceService.ud = mockUserDefaults
+        
+        mockUserDefaults.isValueExists = false
+        
+        // act
+        
+        let result = AppearanceService.DarkModeUserChoice
+        
+        // assert
+        
+        mockUserDefaults.verifyInterger()
+        
+        XCTAssertEqual(result, DARK_MODE_USER_CHOICE_DEFAULT)
+        
+        // keep it clean for the others
+        
+        AppearanceService.ud = UserDefaults.standard
+    }
+    
+    func test_set_DarkModeUserChoice()
+    {
+        // arrange
+        
+        let mockUserDefaults = MockUserDefaults()
+        AppearanceService.ud = mockUserDefaults
+        
+        let sut = DarkModeOption.off
+        
+        // act
+        
+        AppearanceService.DarkModeUserChoice = sut
+        
+        // assert
+        
+        mockUserDefaults.verifySetValue(value: sut.rawValue,
+                                        key  : DARK_MODE_USER_CHOICE_OPTION_KEY)
+        
+        // keep it clean for the others
+        
+        AppearanceService.ud = UserDefaults.standard
     }
 }

--- a/Tests/DarkModeTests/DarkModeTests.swift
+++ b/Tests/DarkModeTests/DarkModeTests.swift
@@ -13,10 +13,66 @@ import XCTest
 
 final class DarkModeTests: XCTestCase
 {
-    func test_init()
+    func test_DarkMode_observable()
     {
-        let sut = DarkMode()
+        // arrange
         
-        XCTAssertNil(sut.userDefaults)
+        var count     : Int = 0
+        var collection: [AppearanceStyle] = []
+        
+        var observer:DarkModeObserver? = DarkModeObserver(AppearanceService.shared)
+        observer?.action =
+            { newStyle in
+                
+                if let style = newStyle
+                {
+                    collection.append(style)
+                    count += 1
+                }
+            }
+        
+        // act
+        
+        AppearanceService.shared._style = AppearanceStyle.dark
+        AppearanceService.shared._style = AppearanceStyle.light
+        
+        // assert
+        
+        XCTAssertEqual(count, 2)
+        XCTAssertEqual(collection, [AppearanceStyle.dark, AppearanceStyle.light])
+        
+        // keep the room clean
+        
+        observer = nil
+    }
+    
+    func test_DarkMode_not_observable()
+    {
+        // arrange
+        
+        var count     : Int = 0
+        var collection: [AppearanceStyle] = []
+        
+        var observer:DarkModeObserver? = DarkModeObserver(AppearanceService.shared)
+        observer?.action =
+            { newStyle in
+                
+                if let style = newStyle
+                {
+                    collection.append(style)
+                    count += 1
+                }
+            }
+        
+        // act
+        observer = nil
+        
+        AppearanceService.shared._style = AppearanceStyle.dark
+        AppearanceService.shared._style = AppearanceStyle.light
+        
+        // assert
+        
+        XCTAssertEqual(count, 0)
+        XCTAssertEqual(collection, [])
     }
 }

--- a/Tests/DarkModeTests/Helpers/ColorVerifier.swift
+++ b/Tests/DarkModeTests/Helpers/ColorVerifier.swift
@@ -27,12 +27,12 @@ final class ColorVerifier
         }
         else
         {
-            AppearanceService.shared.DarkModeUserChoice = .off
+            AppearanceService.DarkModeUserChoice = .off
             AppearanceService.makeUp()
             
             XCTAssertEqual(requirement.color, requiredLight)
             
-            AppearanceService.shared.DarkModeUserChoice = .on
+            AppearanceService.DarkModeUserChoice = .on
             AppearanceService.makeUp()
             
             XCTAssertEqual(requirement.color, requiredDark)

--- a/Tests/DarkModeTests/Helpers/MockNotificationCenter.swift
+++ b/Tests/DarkModeTests/Helpers/MockNotificationCenter.swift
@@ -1,5 +1,5 @@
 //
-//  MockNotificationCenter.swift
+// MockNotificationCenter.swift
 // DarkModeTests
 //
 // Copyright © 2022 Mikhail Zhigulin. All rights reserved.
@@ -16,7 +16,7 @@ class MockNotificationCenter: NotificationCenterProtocol
     // MARK: - addObserver
     
     var registerCallCount = 0
-    var registerArgs_observers : [UIResponder] = []
+    var registerArgs_observers: [UIResponder] = []
     var registerArgs_selectors: [Selector] = []
     
     func addObserver(_ observer        : Any,

--- a/Tests/DarkModeTests/Helpers/MockUserDefaults.swift
+++ b/Tests/DarkModeTests/Helpers/MockUserDefaults.swift
@@ -1,0 +1,138 @@
+//
+// MockUserDefaults.swift
+// DarkModeTests
+//
+// Copyright © 2022 Mikhail Zhigulin. All rights reserved.
+
+import XCTest
+@testable import PerseusDarkMode
+
+class MockUserDefaults: UserDefaultsProtocol
+{
+    var isValueExists = false
+    func valueExists(forKey key: String) -> Bool { isValueExists }
+    
+    // MARK: - getValue
+    
+    var intergerCallCount = 0
+    var intergerArgs_names : [String] = []
+    
+    func integer(forKey defaultName: String) -> Int
+    {
+        intergerCallCount += 1
+        intergerArgs_names.append(defaultName)
+        
+        return 0
+    }
+    
+    func verifyInterger(name: String,
+                        file: StaticString = #file,
+                        line: UInt = #line)
+    {
+        guard intergerWasCalledOnce(file: file, line: line) else { return }
+        
+        XCTAssertTrue(intergerArgs_names.first! == name, "interger", file: file, line: line)
+    }
+    
+    func verifyInterger(file: StaticString = #file,
+                        line: UInt = #line)
+    {
+        guard intergerWasNotCalled(file: file, line: line) else { return }
+        
+        XCTAssertTrue(intergerArgs_names.isEmpty, "interger", file: file, line: line)
+    }
+    
+    private func intergerWasCalledOnce(file: StaticString = #file, line: UInt = #line) -> Bool
+    {
+        verifyMethodCalledOnce(
+            methodName       : "interger",
+            callCount        : intergerCallCount,
+            describeArguments: "name: \(intergerArgs_names)",
+            file             : file,
+            line             : line)
+    }
+    
+    private func intergerWasNotCalled(file: StaticString = #file, line: UInt = #line) -> Bool
+    {
+        verifyMethodNotCalled(
+            methodName       : "interger",
+            callCount        : intergerCallCount,
+            describeArguments: "name: \(intergerArgs_names)",
+            file             : file,
+            line             : line)
+    }
+    
+    // MARK: - setValue
+    
+    var setValueCallCount = 0
+    
+    var setValueArgs_values: [Int] = []
+    var setValueArgs_keys : [String] = []
+    
+    func setValue(_ value: Any?, forKey key: String)
+    {
+        setValueCallCount += 1
+        
+        setValueArgs_values.append(value as! Int)
+        setValueArgs_keys.append(key)
+    }
+    
+    func verifySetValue(value: Int,
+                        key  : String,
+                        file : StaticString = #file,
+                        line : UInt = #line)
+    {
+        guard setValueWasCalledOnce(file: file, line: line) else { return }
+        
+        XCTAssertTrue(setValueArgs_values.first! == value,
+                      "value", file: file, line: line)
+        
+        XCTAssertEqual(setValueArgs_keys.first, key,
+                       "key", file: file, line: line)
+    }
+    
+    private func setValueWasCalledOnce(file: StaticString = #file, line: UInt = #line) -> Bool
+    {
+        verifyMethodCalledOnce(
+            methodName       : "setValue",
+            callCount        : setValueCallCount,
+            describeArguments: "keys: \(setValueArgs_keys)",
+            file             : file,
+            line             : line)
+    }
+}
+
+fileprivate func verifyMethodCalledOnce(methodName       : String, callCount: Int,
+                                        describeArguments: @autoclosure () -> String,
+                                        file             : StaticString = #file,
+                                        line             : UInt = #line) -> Bool
+{
+    if callCount == 0
+    {
+        XCTFail("Wanted but not invoked: \(methodName)", file: file, line: line)
+        return false
+    }
+    
+    if callCount > 1
+    {
+        XCTFail("Wanted 1 time but was called \(callCount) times. " +
+                    "\(methodName) with \(describeArguments())", file: file, line: line)
+        return false
+    }
+    
+    return true
+}
+
+fileprivate func verifyMethodNotCalled(methodName       : String, callCount: Int,
+                                       describeArguments: @autoclosure () -> String,
+                                       file             : StaticString = #file,
+                                       line             : UInt = #line) -> Bool
+{
+    if callCount != 0
+    {
+        XCTFail("Don't wanted but invoked: \(methodName)", file: file, line: line)
+        return false
+    }
+    
+    return true
+}


### PR DESCRIPTION
A set of unit tests was included to cover [DarkMode].

ADDED: A set of unit tests to cover KVO usage of Dark Mode.

ADDED: Unit tests for [DarkModeUserChoice].

ADDED: Predefined sample class to observe Dark Mode [DarkModeObserver].

MOVED: [SystemStyle] calculation from [DarkModeDecision] to [AppearanceService] and now used as a computed property.

MOVED: [DarkModeUserChoice] from [DarkMode] to [AppearanceService].