### PR TITLE
Fix pod spec

### DIFF
--- a/PerseusDarkMode.podspec
+++ b/PerseusDarkMode.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |p|
 
 p.name           = "PerseusDarkMode"
-p.version        = "1.1.0"
+p.version        = "1.1.1"
 p.summary        = "It gives an accessible variable of Dark Mode."
 p.description    = "Designed for constructing Dark Mode sensitive features."
 p.homepage       = "https://github.com/perseusrealdeal/PerseusDarkMode"

--- a/PerseusDarkModeSingle.swift
+++ b/PerseusDarkModeSingle.swift
@@ -1,6 +1,6 @@
 //
 //  PerseusDarkModeSingle.swift
-//  Version: 1.1.0
+//  Version: 1.1.1
 //
 //  Created by Mikhail Zhigulin in 7530.
 //

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Perseus Dark Mode
 
 [![Actions Status](https://github.com/perseusrealdeal/DarkMode/actions/workflows/main.yml/badge.svg)](https://github.com/perseusrealdeal/PerseusDarkMode/actions)
-![Version](https://img.shields.io/badge/Version-1.1.0-informational.svg)
-![Pod](https://img.shields.io/badge/Pod-1.1.0-informational.svg)
+![Version](https://img.shields.io/badge/Version-1.1.1-informational.svg)
+![Pod](https://img.shields.io/badge/Pod-1.1.1-informational.svg)
 ![Platforms](https://img.shields.io/badge/Platforms-iOS%209.3+,%20macOS%2010.9+-orange.svg)
 [![Swift 4.2](https://img.shields.io/badge/Swift-4.2-red.svg)](https://docs.swift.org/swift-book/RevisionHistory/RevisionHistory.html)
 [![License](http://img.shields.io/:License-MIT-blue.svg)](https://github.com/perseusrealdeal/PerseusDarkMode/blob/7c2955094f4fd24d2b9d4c4d87780616e5361be7/LICENSE)
@@ -51,7 +51,7 @@ Podfile should contain:
 ```ruby
 target "ProjectTarget" do
   use_frameworks!
-  pod 'PerseusDarkMode', '1.1.0'
+  pod 'PerseusDarkMode', '1.1.1'
 end
 ```
 #### Carthage
@@ -59,7 +59,7 @@ end
 Carfile should contain:
 
 ```carthage
-github "perseusrealdeal/PerseusDarkMode" == 1.1.0
+github "perseusrealdeal/PerseusDarkMode" == 1.1.1
 ```
 
 [HowTo](https://gist.github.com/perseusrealdeal/8951b10f4330325df6347aaaa79d3cf2) add swift package to a host project with Carthage.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ github "perseusrealdeal/PerseusDarkMode" == 1.1.1
 ```swift
 dependencies: [
         .package(url: "https://github.com/perseusrealdeal/PerseusDarkMode.git",
-            .exact("1.1.0"))
+            .exact("1.1.1"))
     ],
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Integration Capabilities
 
-[![Standalone File](https://img.shields.io/badge/Standalone%20File-available-informational.svg)](https://github.com/perseusrealdeal/PerseusDarkMode/blob/7c2955094f4fd24d2b9d4c4d87780616e5361be7/PerseusDarkModeSingle.swift)
+[![Standalone File](https://img.shields.io/badge/Standalone%20File-available-informational.svg)](https://github.com/perseusrealdeal/PerseusDarkMode/blob/a9cae9befe54dfc33d5815ffdcd39ca9da3323a3/PerseusDarkModeSingle.swift)
 [![CocoaPods manager](https://img.shields.io/badge/CocoaPods-compatible-4BC51D.svg)](https://cocoapods.org)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg)](https://github.com/Carthage/Carthage)
 [![Swift Package Manager compatible](https://img.shields.io/badge/Swift%20Package%20Manager-compatible-4BC51D.svg)](https://github.com/apple/swift-package-manager)


### PR DESCRIPTION
FIXED: Cocoa pod spec with tag platform.

CHANGED: Tag platform > deployment_target both for iOS and macOS.

UPDATED: Library version.